### PR TITLE
Aromatics

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Molecules are depicted as [Networkx][networkx] graphs. Atoms are the nodes of
 the graph, and bonds are the edges. Nodes can have the following attributes:
 - element: str. This describes the element of the atom. Defaults to '\*'
     meaning unknown.
-- aromatic: bool. Whether this atom is part of an aromatic system. Defaults to
-    False.
+- aromatic: bool. Whether the atom is part of an (anti)-aromatic system. 
+    Defaults to False.
 - isotope: float. The mass of the atom. Defaults to unknown.
 - hcount: int. The number of implicit hydrogens attached to this atom.
     Defaults to 0.
@@ -31,16 +31,15 @@ There is currently no way of specifying stereo chemical information, and this
 is discarded upon reading. Somewhere in the future this will probably be
 stored in the "stereo" attribute of nodes.
 
-When reading SMILES edges in the created molecule will always have an 'order'
-attribute. Nodes will have the relevant attributes in so far they are
-specified. Atoms for which the element is not known (\*) will not have an
-element attribute.
-
 ## Reading SMILES
 The function `read_smiles(smiles, explicit_hydrogen=False,
 zero_order_bonds=True, reinterpret_aromatic=True)` can be used to parse a
 SMILES string. It should not be used to validate whether a string is a valid
 SMILES string --- the function does very little validation whether your SMILES string makes chemical sense.
+Edges in the created molecule will always have an 'order'
+attribute. Nodes will have the relevant attributes in so far they are
+specified. Atoms for which the element is not known (\*) will not have an
+element attribute.
 - `explicit_hydrogen` determines whether hydrogen atoms should be
     represented as explicit nodes in the created molecule, or implicit in the
     'hcount' attribute.
@@ -48,11 +47,11 @@ SMILES string --- the function does very little validation whether your SMILES s
     string should result in edges in the produced molecule.
 - `reinterpret_aromatic` determines whether aromaticity should be 
     reinterpreted, and determined from the constructed molecule, or whether
-    the aromaticity specifications from the SMILES string (lower case letters) 
-    should be taken as leading. If `True`, will also set bond orders to 1 for 
-    bonds that are not part of a ring and have a bond order of 1.5.
-    If `False`, will create a molecule using *only* the information in the
-    SMILES string.
+    the aromaticity specifications from the SMILES string (lower case 
+    elements) should be taken as leading. If `True`, will also set bond orders 
+    to 1 for bonds that are not part of an aromatic ring and have a bond order 
+    of 1.5. If `False`, will create a molecule using *only* the information in 
+    the SMILES string.
 
 ## Writing SMILES
 The function `write_smiles(molecule, default_element='*', start=None)` can be
@@ -89,13 +88,13 @@ can help in creating chemically relevant molecules with minimal work.
     to figure our which atoms are aromatic. It works by first finding all 
     atoms that are in a ring. Next, for every atom in every ring it is checked
     whether the atoms are sp2 hybridized (note that this is a vague term. 
-    Strictly speaking we check whether there element is something that *could*
+    Strictly speaking we check whether their element is something that *could*
     be aromatic, and whether they have 2 or 3 bonds.). Finally, the number of 
     electrons per ring is counted, and if this is even, the atoms in the ring
     are said to be aromatic.
     This function is the most fragile in the whole library, and I expect it to
     produce wrong answers in some cases. In particular for fused (aromatic)
-    ring systems (such as indole) and ring with extracyclic heteroatoms
+    ring systems (such as indole) and rings with extracyclic heteroatoms
     (O=C1C=CC=C1). Buyer beware.
 
 ## Examples
@@ -198,7 +197,7 @@ print(write_smiles(mol))
 - There is currently no way of specifying stereo chemical information. The 
     parser can deal with it, but it will be discarded.
 - It is not on PyPI
-- It only process SMILES. This might later be extended to e.g. InChi, SLN,
+- It only processes SMILES. This might later be extended to e.g. InChi, SLN,
     SMARTS, etc.
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -8,16 +8,95 @@ writer that was easy to install (read: Python only). Currently, the writer is
 extremely basic, and although it should produce valid SMILES they won't be
 pretty. The reader is in a better state, and should be usable.
 
-SMILES strings are assumed to be as specified by the 
+SMILES strings are assumed to be as specified by the
 [OpenSmiles standard][opensmiles].
 
 ## Molecules
 Molecules are depicted as [Networkx][networkx] graphs. Atoms are the nodes of
 the graph, and bonds are the edges. Nodes can have the following attributes:
-"element", "aromatic", "isotope", "hcount", "charge", and "class". There is currently no
-way of specifying stereochemical information, and this is discarded upon
-reading. Somewhere in the future this will probably be stored in the "stereo"
-attribute of nodes. Edges will have an "order" attribute.
+- element: str. This describes the element of the atom. Defaults to '\*'
+    meaning unknown.
+- aromatic: bool. Whether this atom is part of an aromatic system. Defaults to
+    False.
+- isotope: float. The mass of the atom. Defaults to unknown.
+- hcount: int. The number of implicit hydrogens attached to this atom.
+    Defaults to 0.
+- charge: int. The charge of this atom. Defaults to 0.
+- class: int. The "class" of this atom. Defaults to 0.
+
+Edges have the following attributes:
+- order: Number. The bond order. 1.5 is used for aromatic bonds. Defaults to 1.
+
+There is currently no way of specifying stereo chemical information, and this
+is discarded upon reading. Somewhere in the future this will probably be
+stored in the "stereo" attribute of nodes.
+
+When reading SMILES edges in the created molecule will always have an 'order'
+attribute. Nodes will have the relevant attributes in so far they are
+specified. Atoms for which the element is not known (\*) will not have an
+element attribute.
+
+## Reading SMILES
+The function `read_smiles(smiles, explicit_hydrogen=False,
+zero_order_bonds=True, reinterpret_aromatic=True)` can be used to parse a
+SMILES string. It should not be used to validate whether a string is a valid
+SMILES string --- the function does very little validation whether your SMILES string makes chemical sense.
+- `explicit_hydrogen` determines whether hydrogen atoms should be
+    represented as explicit nodes in the created molecule, or implicit in the
+    'hcount' attribute.
+- `zero_order_bonds` determines whether zero-order bonds (.) in the SMILES
+    string should result in edges in the produced molecule.
+- `reinterpret_aromatic` determines whether aromaticity should be 
+    reinterpreted, and determined from the constructed molecule, or whether
+    the aromaticity specifications from the SMILES string (lower case letters) 
+    should be taken as leading. If `True`, will also set bond orders to 1 for 
+    bonds that are not part of a ring and have a bond order of 1.5.
+    If `False`, will create a molecule using *only* the information in the
+    SMILES string.
+
+## Writing SMILES
+The function `write_smiles(molecule, default_element='*', start=None)` can be
+used to write SMILES strings from a molecule. The function does *not* check 
+whether your molecule makes chemical sense. Instead, it writes a SMILES 
+representation of the molecule you provided, and nothing else.
+- `default_element` is the element to use for nodes that do not have an 
+    'element' attribute.
+- `start` is the key of the node where the depth first traversal should be 
+    started. Something clever is done if not specified.
+
+## Additional functions
+In addition to these two core functions, four more functions are exposed that
+can help in creating chemically relevant molecules with minimal work.
+
+- `fill_valence(mol, respect_hcount=True, respect_bond_order=True,
+                 max_bond_order=3)`
+    This function will fill the valence of all atoms in your molecule by 
+    incrementing the 'hcount' and, if specified, bond orders. Note that it does
+    not use 'charge' attribute to find the correct valence.
+    - `repect_hcount`: bool. Whether existing hcounts can be overwritten.
+    - `respect_bond_order`: bool. Whether bond orders can be changed
+    - `max_bond_order`: int. The maximum bond order that will be set.
+- `add_explicit_hydrogens(mol)`
+    This function transforms implicit hydrogens, specified by 'hcount' 
+    attributes, to explicit nodes.
+- `remove_explicit_hydrogens(mol)`
+    This function does the inverse of `add_explicit_hydrogens`: it will remove
+    explicit hydrogen nodes and add them to the relevant 'hcount' attributes.
+- `correct_aromatic_rings(mol)`
+    This function marks all (anti)-aromatic atoms in your molecule, and sets 
+    all bonds between (anti)-aromatic atoms to order 1.5.
+    It fills the valence of all atoms (see also `fill_valence`) before trying
+    to figure our which atoms are aromatic. It works by first finding all 
+    atoms that are in a ring. Next, for every atom in every ring it is checked
+    whether the atoms are sp2 hybridized (note that this is a vague term. 
+    Strictly speaking we check whether there element is something that *could*
+    be aromatic, and whether they have 2 or 3 bonds.). Finally, the number of 
+    electrons per ring is counted, and if this is even, the atoms in the ring
+    are said to be aromatic.
+    This function is the most fragile in the whole library, and I expect it to
+    produce wrong answers in some cases. In particular for fused (aromatic)
+    ring systems (such as indole) and ring with extracyclic heteroatoms
+    (O=C1C=CC=C1). Buyer beware.
 
 ## Examples
 ### Reading
@@ -28,55 +107,116 @@ smiles = 'C1CC[13CH2]CC1C1CCCCC1'
 mol = read_smiles(smiles)
 
 print(mol.nodes(data='element'))
-#  [(0, 'C'), (1, 'C'), (2, 'C'), (3, 'C'), (4, 'C'), (5, 'C'), (6, 'C'),
-#   (7, 'C'), (8, 'C'), (9, 'C'), (10, 'C'), (11, 'C'), (12, 'H'), (13, 'H'),
-#   (14, 'H'), (15, 'H'), (16, 'H'), (17, 'H'), (18, 'H'), (19, 'H'),
-#   (20, 'H'), (21, 'H'), (22, 'H'), (23, 'H'), (24, 'H'), (25, 'H'),
-#   (26, 'H'), (27, 'H'), (28, 'H'), (29, 'H'), (30, 'H'), (31, 'H'),
-#   (32, 'H'), (33, 'H')]
+# [(0, 'C'),
+#  (1, 'C'),
+#  (2, 'C'),
+#  (3, 'C'),
+#  (4, 'C'),
+#  (5, 'C'),
+#  (6, 'C'),
+#  (7, 'C'),
+#  (8, 'C'),
+#  (9, 'C'),
+#  (10, 'C'),
+#  (11, 'C')]
+print(mol.nodes(data='hcount'))
+# [(0, 2),
+#  (1, 2),
+#  (2, 2),
+#  (3, 2),
+#  (4, 2),
+#  (5, 1),
+#  (6, 1),
+#  (7, 2),
+#  (8, 2),
+#  (9, 2),
+#  (10, 2),
+#  (11, 2)]
 
-mol_without_H = read_smiles(smiles, explicit_H=False)
-print(mol_without_H.nodes(data='element'))
-# [(0, 'C'), (1, 'C'), (2, 'C'), (3, 'C'), (4, 'C'), (5, 'C'), (6, 'C'),
-#  (7, 'C'), (8, 'C'), (9, 'C'), (10, 'C'), (11, 'C')]
-print(mol_without_H.nodes(data='hcount'))
-# [(0, 2), (1, 2), (2, 2), (3, 2), (4, 2), (5, 1), (6, 1), (7, 2), (8, 2),
-#  (9, 2), (10, 2), (11, 2)]
+mol_with_H = read_smiles(smiles, explicit_hydrogen=True)
+print(mol_with_H.nodes(data='element'))
+# [(0, 'C'),
+#  (1, 'C'),
+#  (2, 'C'),
+#  (3, 'C'),
+#  (4, 'C'),
+#  (5, 'C'),
+#  (6, 'C'),
+#  (7, 'C'),
+#  (8, 'C'),
+#  (9, 'C'),
+#  (10, 'C'),
+#  (11, 'C'),
+#  (12, 'H'),
+#  (13, 'H'),
+#  (14, 'H'),
+#  (15, 'H'),
+#  (16, 'H'),
+#  (17, 'H'),
+#  (18, 'H'),
+#  (19, 'H'),
+#  (20, 'H'),
+#  (21, 'H'),
+#  (22, 'H'),
+#  (23, 'H'),
+#  (24, 'H'),
+#  (25, 'H'),
+#  (26, 'H'),
+#  (27, 'H'),
+#  (28, 'H'),
+#  (29, 'H'),
+#  (30, 'H'),
+#  (31, 'H'),
+#  (32, 'H'),
+# (33, 'H')]
 ```
 
 ### Writing
 ```python
 import networkx as nx
-from pysmiles import write_smiles
+from pysmiles import write_smiles, fill_valence
 
 mol = nx.Graph()
 mol.add_edges_from([(0, 1), (1, 2), (1, 3), (3, 4), (1, 5), (3, 6)])
 for idx, ele in enumerate('CCCCOCO'):
     mol.nodes[idx]['element'] = ele
 mol.nodes[4]['charge'] = -1
+mol.nodes[4]['hcount'] = 0
 mol.edges[3, 6]['order'] = 2
 
 print(write_smiles(mol))
-# CC(C)(C(=O)[O-])C
+# [O-]C(=O)C([C])([C])[C]
+fill_valence(mol, respect_hcount=True)
+print(write_smiles(mol))
+# [O-]C(=O)C(C)(C)C
 ```
 
 ## Limitations
-- The writer produces non-recommended SMILES strings (as per OpenSmiles). In
-    addition, it doesn't use the 'hcount' and valence to determine bond orders.
-- There is currently no way of specifying stereochemical information. The parser
-    can deal with it, but it will be discarded.
-- There are not enough tests.
+- The writer produces non-recommended SMILES strings (as per OpenSmiles).
+- `fill_valence` does not use 'charge' to find the correct valence.
+- `correct_aromatic_rings` is fragile.
+- There is currently no way of specifying stereo chemical information. The 
+    parser can deal with it, but it will be discarded.
 - It is not on PyPI
-- It only process SMILES. This might later be extended to e.g. InChi, SLN, SMARTS, etc.
+- It only process SMILES. This might later be extended to e.g. InChi, SLN,
+    SMARTS, etc.
 
 ## Requirements
 - [networkx][networkx]
 
 ## Similar projects
-There are more python projects that deal with SMILES, and I try to list at least some of them here. If yours is missing, feel free to open up a PR.
-- [PySMILE](https://github.com/jhosmer/PySmile): A similar named project, capable of encoding/decoding SMILE format objects. Doesn't deal with SMILES.
-- [RDKit](https://github.com/rdkit/rdkit): A collection of cheminformatics and machine-learning software, capable of reading and writing SMILES, InChi, and others.
-- [OpenEye Chem toolkit](https://www.eyesopen.com/oechem-tk): The OpenEye chemistry toolkit is a programming library for chemistry and cheminformatics. It is capable of dealing with (canonical) SMILES and InChi.
+There are more python projects that deal with SMILES, and I try to list at 
+least some of them here. If yours is missing, feel free to open up a PR.
+- [PySMILE](https://github.com/jhosmer/PySmile): A similar named project, 
+    capable of encoding/decoding SMILE format objects. Doesn't deal with 
+    SMILES.
+- [RDKit](https://github.com/rdkit/rdkit): A collection of cheminformatics and 
+    machine-learning software, capable of reading and writing SMILES, InChi, 
+    and others.
+- [OpenEye Chem toolkit](https://www.eyesopen.com/oechem-tk): The OpenEye 
+    chemistry toolkit is a programming library for chemistry and 
+    cheminformatics. It is capable of dealing with (canonical) SMILES and 
+    InChi.
 
 ## License
 PySmiles is distributed under the Apache 2.0 license.

--- a/pysmiles/smiles_helper.py
+++ b/pysmiles/smiles_helper.py
@@ -139,7 +139,7 @@ def format_atom(molecule, node_key, default_element='*'):
         name = name.lower()
 
     if (stereo is None and isotope == '' and charge == 0 and default_h and
-            class_ == '' and name.lower() in 'b c n o p s se as'.split()):
+            class_ == '' and name.lower() in 'b c n o p s se as *'.split()):
         return name
 
     if hcount:

--- a/tests/test_hypothesis.py
+++ b/tests/test_hypothesis.py
@@ -85,9 +85,11 @@ class SMILESTest(RuleBasedStateMachine):
     def remove_explicit_hydrogens(self):
         remove_explicit_hydrogens(self.mol)
 
-    @rule()
-    def correct_aromatic_rings(self):
-        correct_aromatic_rings(self.mol)
+    # We can't run this halfway through, because aromaticity does not always get
+    # encoded in the SMILES string. In particular when * elements are involved.
+    # @rule()
+    # def correct_aromatic_rings(self):
+    #     correct_aromatic_rings(self.mol)
 
     @rule()
     def fill_valence(self):
@@ -119,12 +121,8 @@ class SMILESTest(RuleBasedStateMachine):
                 add_explicit_hydrogens(ref_mol)
             else:
                 remove_explicit_hydrogens(ref_mol)
-            # '*' elements may be aromatic, but not detected as such.
-            no_element = {n_idx for n_idx in ref_mol
-                          if ref_mol.nodes[n_idx].get('element', '*') == '*'}
-            mark_aromatic_atoms(ref_mol, atoms=no_element)
-            mark_aromatic_edges(ref_mol)
-            found = read_smiles(smiles, explicit_hydrogen=expl_H)
+            found = read_smiles(smiles, explicit_hydrogen=expl_H,
+                                reinterpret_aromatic=False)
             note(found.nodes(data=True))
             note(found.edges(data=True))
             assertEqualGraphs(ref_mol, found)

--- a/tests/test_read_smiles.py
+++ b/tests/test_read_smiles.py
@@ -374,12 +374,12 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
     ),
     (
         '[cH-1]1[cH-1][cH-1]1',
-        [(0, {'element': 'C', 'aromatic': True, 'charge': -1, 'hcount': 1}),
-         (1, {'element': 'C', 'aromatic': True, 'charge': -1, 'hcount': 1}),
-         (2, {'element': 'C', 'aromatic': True, 'charge': -1, 'hcount': 1})],
-        [(0, 1, {'order': 1.5}),
-         (1, 2, {'order': 1.5}),
-         (2, 0, {'order': 1.5})],
+        [(0, {'element': 'C', 'aromatic': False, 'charge': -1, 'hcount': 1}),
+         (1, {'element': 'C', 'aromatic': False, 'charge': -1, 'hcount': 1}),
+         (2, {'element': 'C', 'aromatic': False, 'charge': -1, 'hcount': 1})],
+        [(0, 1, {'order': 1}),
+         (1, 2, {'order': 1}),
+         (2, 0, {'order': 1})],
         False
     ),
     (
@@ -464,17 +464,19 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
     ),
     (
         'N1[*][*]1',
-        [(0, {'element': 'N', 'charge': 0, 'aromatic': False, 'hcount': 1}),
+        [(0, {'element': 'N', 'charge': 0, 'aromatic': True, 'hcount': 1}),
          (1, {'charge': 0, 'aromatic': True, 'hcount': 0}),
          (2, {'charge': 0, 'aromatic': True, 'hcount': 0})],
-        [(0, 1, {'order': 1}),
+        [(0, 1, {'order': 1.5}),
          (1, 2, {'order': 1.5}),
-         (2, 0, {'order': 1}),],
+         (2, 0, {'order': 1.5}),],
         False
     )
 ))
 def test_read_smiles(smiles, node_data, edge_data, explicit_h):
     found = read_smiles(smiles, explicit_hydrogen=explicit_h)
+    print(found.nodes(data=True))
+    print(found.edges(data=True))
     expected = make_mol(node_data, edge_data)
     assertEqualGraphs(found, expected)
 

--- a/tests/test_write_smiles.py
+++ b/tests/test_write_smiles.py
@@ -134,5 +134,5 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
 def test_write_smiles(node_data, edge_data, expl_h):
     mol = make_mol(node_data, edge_data)
     smiles = write_smiles(mol)
-    found = read_smiles(smiles, explicit_hydrogen=expl_h)
+    found = read_smiles(smiles, explicit_hydrogen=expl_h, reinterpret_aromatic=False)
     assertEqualGraphs(mol, found)


### PR DESCRIPTION
Change the handling of aromaticity to make sure it is only reinterpreted when explicitly asked. This also makes testing easier, since the reader and writer come closer to (de)serializers. The exception is the '*' element where the writer can't encode the aromaticity.