### PR TITLE
Added Silent Parameter to read_smiles()

### DIFF
--- a/pysmiles/read_smiles.py
+++ b/pysmiles/read_smiles.py
@@ -93,7 +93,7 @@ def _tokenize(smiles):
 
 
 def read_smiles(smiles, explicit_hydrogen=False, zero_order_bonds=True, 
-                reinterpret_aromatic=True):
+                reinterpret_aromatic=True, silent=False):
     """
     Parses a SMILES string.
 
@@ -176,7 +176,7 @@ def read_smiles(smiles, explicit_hydrogen=False, zero_order_bonds=True,
                 # idx is the index of the *next* atom we're adding. So: -1.
                 ring_nums[token] = (idx - 1, next_bond)
                 next_bond = None
-        elif tokentype == TokenType.EZSTEREO:
+        elif tokentype == TokenType.EZSTEREO and silent==False:
             LOGGER.warning('E/Z stereochemical information, which is specified by "%s", will be discarded', token)
     if ring_nums:
         raise KeyError('Unmatched ring indices {}'.format(list(ring_nums.keys())))


### PR DESCRIPTION
Right now the logger always warns when stereochemical information is lost.

That means when you are reading thousands of molecules you get thousands of lines printed to ``__name__`` like:

`
Atom "[C@H]" contains stereochemical information that will be discarded.
Atom "[C@@H]" contains stereochemical information that will be discarded.
Atom "[C@H]" contains stereochemical information that will be discarded.
E/Z stereochemical information, which is specified by "/", will be discarded
E/Z stereochemical information, which is specified by "/", will be discarded
E/Z stereochemical information, which is specified by "/", will be discarded
E/Z stereochemical information, which is specified by "/", will be discarded
Atom "[C@H]" contains stereochemical information that will be discarded.
Atom "[C@@H]" contains stereochemical information that will be discarded.
Atom "[C@H]" contains stereochemical information that will be discarded.
Atom "[C@@H]" contains stereochemical information that will be discarded.
Atom "[C@H]" contains stereochemical information that will be discarded.
Atom "[C@@H]" contains stereochemical information that will be discarded.
Atom "[C@@H]" contains stereochemical information that will be discarded.
Atom "[C@H]" contains stereochemical information that will be discarded.
Atom "[C@@H]" contains stereochemical information that will be discarded.
Atom "[C@]" contains stereochemical information that will be discarded.
Atom "[C@H]" contains stereochemical information that will be discarded.
`

I added the optional parameter silent into read_smiles() default = False.

A user can now use read smiles(smile, silent=True) and now the warnings won't clutter up the output.