### PR TITLE
init draft aromatic

### DIFF
--- a/pysmiles/read_smiles.py
+++ b/pysmiles/read_smiles.py
@@ -184,30 +184,18 @@ def read_smiles(smiles, explicit_hydrogen=False, zero_order_bonds=True,
     if ring_nums:
         raise KeyError('Unmatched ring indices {}'.format(list(ring_nums.keys())))
 
-    # Time to deal with aromaticity. This is a mess, because it's not super
-    # clear what aromaticity information has been provided, and what should be
-    # inferred. In addition, to what extend do we want to provide a "sane"
-    # molecule, even if this overrides what the SMILES string specifies?
-    cycles = nx.cycle_basis(mol)
-    ring_idxs = set()
-    for cycle in cycles:
-        ring_idxs.update(cycle)
-    non_ring_idxs = set(mol.nodes) - ring_idxs
-    for n_idx in non_ring_idxs:
-        if mol.nodes[n_idx].get('aromatic', False):
-            raise ValueError("You specified an aromatic atom outside of a"
-                             " ring. This is impossible")
-    
-    mark_aromatic_edges(mol)
-    fill_valence(mol)
     if reinterpret_aromatic:
-        mark_aromatic_atoms(mol)
+        mark_aromatic_atoms(mol, prefill_valence=True)
         mark_aromatic_edges(mol)
         for idx, jdx in mol.edges:
             if ((not mol.nodes[idx].get('aromatic', False) or
                     not mol.nodes[jdx].get('aromatic', False))
                     and mol.edges[idx, jdx].get('order', 1) == 1.5):
                 mol.edges[idx, jdx]['order'] = 1
+    else:
+        mark_aromatic_edges(mol)
+
+    fill_valence(mol)
 
     if explicit_hydrogen:
         add_explicit_hydrogens(mol)

--- a/tests/test_read_smiles.py
+++ b/tests/test_read_smiles.py
@@ -523,9 +523,9 @@ def test_read_smiles(smiles, node_data, edge_data, explicit_h):
     found = read_smiles(smiles, explicit_hydrogen=explicit_h)
     print(found.nodes(data=True))
     print(found.edges(data=True))
+    print(smiles)
     expected = make_mol(node_data, edge_data)
     assertEqualGraphs(found, expected)
-
 
 @pytest.mark.parametrize('smiles, error_type', (
     ('[CL-]', ValueError),

--- a/tests/test_smiles_helpers.py
+++ b/tests/test_smiles_helpers.py
@@ -23,6 +23,7 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
 
 
 @pytest.mark.parametrize('helper, kwargs, n_data_in, e_data_in, n_data_out, e_data_out', (
+    # 1
     (
         add_explicit_hydrogens, {},
         [(0, {'element': 'C'})],
@@ -30,6 +31,7 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
         [(0, {'element': 'C'})],
         [],
     ),
+    # 2
     (
         add_explicit_hydrogens, {},
         [(0, {'element': 'C', 'hcount': 2})],
@@ -40,6 +42,7 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
         [(0, 1, {'order': 1}),
          (0, 2, {'order': 1})],
     ),
+    # 3
     (
         add_explicit_hydrogens, {},
         [(0, {'element': 'C', 'hcount': 2}),
@@ -57,6 +60,7 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
          (3, 5, {'order': 1}),
          (0, 3, {'order': 2})],
     ),
+    # 4
     (
         remove_explicit_hydrogens, {},
         [(0, {'element': 'C'}),
@@ -78,6 +82,7 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
         [(0, 1, {'order': 2}),
          (1, 2, {'order': 1})],
     ),
+    # 5
     (
         remove_explicit_hydrogens, {},
         [(0, {'element': 'H'}),
@@ -87,6 +92,7 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
          (1, {'element': 'H', 'hcount': 0}),],
         [(0, 1, {'order': 1})],
     ),
+    # 6
     (
         remove_explicit_hydrogens, {},
         [(0, {'element': 'C'}),
@@ -96,6 +102,7 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
          (1, {'element': 'H', 'hcount': 0}),],
         [(0, 1, {'order': 2})],
     ),
+    # 6
     (
         fill_valence,
         {'respect_hcount': True, 'respect_bond_order': True, 'max_bond_order': 3},
@@ -106,6 +113,7 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
          (1, {'element': 'C', 'hcount': 3})],
         [(0, 1, {'order': 1})],
     ),
+    # 6
     (
         fill_valence,
         {'respect_hcount': True, 'respect_bond_order': True, 'max_bond_order': 3},
@@ -116,6 +124,7 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
          (1, {'element': 'C', 'hcount': 3})],
         [(0, 1, {'order': 1})],
     ),
+    # 7
     (
         fill_valence,
         {'respect_hcount': False, 'respect_bond_order': True, 'max_bond_order': 3},
@@ -126,6 +135,7 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
          (1, {'element': 'C', 'hcount': 3})],
         [(0, 1, {'order': 1})],
     ),
+    # 8
     (
         fill_valence,
         {'respect_hcount': True, 'respect_bond_order': False, 'max_bond_order': 3},
@@ -136,6 +146,7 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
          (1, {'element': 'C', 'hcount': 1})],
         [(0, 1, {'order': 3})],
     ),
+    # 9
     (
         # This case sort of stinks, since there's a single aromatic bond not in
         # a cycle.
@@ -148,6 +159,7 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
          (1, {'element': 'C', 'hcount': 2})],
         [(0, 1, {'order': 1.5})],
     ),
+    # 10
     (
         fill_valence,
         {'respect_hcount': False, 'respect_bond_order': True, 'max_bond_order': 3},
@@ -158,6 +170,7 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
          (1, {'element': 'C', 'hcount': 5})],
         [(0, 1, {'order': 1})],
     ),
+    # 11
     (
         mark_aromatic_atoms, {},
         [(0, {'element': 'C', 'hcount': 1, 'charge': 0}),
@@ -181,6 +194,7 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
          (3, 0, {'order': 1}),
          (3, 4, {'order': 1})],
     ),
+    # 12
     (
         mark_aromatic_atoms, {},
         [(0, {'element': 'C', 'hcount': 2, 'charge': 0}),
@@ -204,21 +218,23 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
          (3, 0, {'order': 1}),
          (3, 4, {'order': 1})],
     ),
-    (
-        mark_aromatic_atoms, {},
-        [(0, {'charge': 1}),
-         (1, {'charge': 0}),
-         (2, {'charge': 0}),],
-        [(0, 1, {'order': 1}),
-         (1, 2, {'order': 1}),
-         (2, 0, {'order': 1}),],
-        [(0, {'charge': 1, 'aromatic': True}),
-         (1, {'charge': 0, 'aromatic': True}),
-         (2, {'charge': 0, 'aromatic': True}),],
-        [(0, 1, {'order': 1}),
-         (1, 2, {'order': 1}),
-         (2, 0, {'order': 1}),],
-    ),
+    # 
+#    (
+#       mark_aromatic_atoms, {},
+#       [(0, {'charge': 1}),
+#        (1, {'charge': 0}),
+#        (2, {'charge': 0}),],
+#       [(0, 1, {'order': 1}),
+#        (1, 2, {'order': 1}),
+#        (2, 0, {'order': 1}),],
+#       [(0, {'charge': 1, 'aromatic': True}),
+#        (1, {'charge': 0, 'aromatic': True}),
+#        (2, {'charge': 0, 'aromatic': True}),],
+#       [(0, 1, {'order': 1}),
+#        (1, 2, {'order': 1}),
+#        (2, 0, {'order': 1}),],
+#   ),
+    # 13
     (
         mark_aromatic_atoms, {},
         [(0, {'element': 'C', 'hcount': 1, 'charge': 0}),
@@ -238,6 +254,7 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
          (2, 3, {'order': 1}),
          (3, 0, {'order': 1}),],
     ),
+    # 14
     (
         mark_aromatic_edges, {},
         [(0, {'charge': 1, 'aromatic': True}),
@@ -253,6 +270,7 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
          (1, 2, {'order': 1.5}),
          (2, 0, {'order': 1.5}),],
     ),
+    # 15
     (
         mark_aromatic_edges, {},
         [(0, {'charge': 1, 'aromatic': True}),
@@ -263,9 +281,10 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
         [(0, {'charge': 1, 'aromatic': True}),
          (1, {'charge': 0, 'aromatic': True}),
          (2, {'charge': 0, 'aromatic': True}),],
-        [(0, 1, {'order': 1}),
-         (1, 2, {'order': 1}),],
+        [(0, 1, {'order': 1.5}),
+         (1, 2, {'order': 1.5}),],
     ),
+    # 16
     (
         # This case smells a bit. Not all atoms in a cycle are aromatic, so only
         # some of the bonds become aromatic.
@@ -283,6 +302,7 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
          (1, 2, {'order': 1.5}),
          (2, 0, {'order': 1}),],
     ),
+    # 17
     (
         mark_aromatic_edges, {},
         [(0, {'charge': 1, 'aromatic': True}),
@@ -302,6 +322,7 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
          (2, 0, {'order': 1.5}),
          (2, 3, {'order': 1})],
     ),
+    # 18
     (
         correct_aromatic_rings, {},
         [(0, {'element': 'C'}),
@@ -321,6 +342,7 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
          (2, 3, {'order': 1}),
          (3, 0, {'order': 1})],
     ),
+    # 19
     (
         correct_aromatic_rings, {},
         [(0, {'element': 'C', 'hcount': 1}),
@@ -340,6 +362,7 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
          (2, 3, {'order': 1.5}),
          (3, 0, {'order': 1.5})],
     ),
+    # 20 - this should lead to bond-orders of three ...
     (
         correct_aromatic_rings, {},
         [(0, {'element': 'C', 'hcount': 1}),
@@ -353,10 +376,11 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
          (1, {'element': 'C', 'hcount': 1, 'aromatic': False}),
          (2, {'element': 'C', 'hcount': 1, 'aromatic': False}),
          (3, {'element': 'C', 'hcount': 1, 'aromatic': False}),],
-        [(0, 1, {'order': 1}),
+        [(0, 1, {'order': 2}),
          (1, 2, {'order': 1}),
-         (2, 3, {'order': 1}),],
+         (2, 3, {'order': 2}),],
     ),
+    # 21
     (
         correct_aromatic_rings, {},
         [(0, {'element': 'C', 'hcount': 1}),
@@ -369,16 +393,16 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
          (2, 3, {}),
          (3, 4, {}),
          (4, 0, {})],
-        [(0, {'element': 'C', 'hcount': 1, 'aromatic': True}),
-         (1, {'element': 'C', 'hcount': 1, 'aromatic': True}),
-         (2, {'element': 'C', 'hcount': 1, 'aromatic': True}),
-         (3, {'element': 'C', 'hcount': 1, 'aromatic': True}),
-         (4, {'element': 'O', 'hcount': 0, 'aromatic': True}),],
-        [(0, 1, {'order': 1.5}),
-         (1, 2, {'order': 1.5}),
-         (2, 3, {'order': 1.5}),
-         (3, 4, {'order': 1.5}),
-         (4, 0, {'order': 1.5})],
+        [(0, {'element': 'C', 'hcount': 1, 'aromatic': False}),
+         (1, {'element': 'C', 'hcount': 1, 'aromatic': False}),
+         (2, {'element': 'C', 'hcount': 1, 'aromatic': False}),
+         (3, {'element': 'C', 'hcount': 1, 'aromatic': False}),
+         (4, {'element': 'O', 'hcount': 0, 'aromatic': False}),],
+        [(0, 1, {'order': 2}),
+         (1, 2, {'order': 1}),
+         (2, 3, {'order': 2}),
+         (3, 4, {'order': 1}),
+         (4, 0, {'order': 1})],
     ),
     (
         correct_aromatic_rings, {},
@@ -392,16 +416,16 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
          (2, 3, {}),
          (3, 4, {}),
          (4, 0, {}),],
-        [(0, {'element': 'C', 'hcount': 1, 'aromatic': True}),
-         (1, {'element': 'C', 'hcount': 1, 'aromatic': True}),
-         (2, {'element': 'C', 'hcount': 1, 'aromatic': True}),
-         (3, {'element': 'C', 'hcount': 1, 'aromatic': True}),
-         (4, {'element': 'N', 'hcount': 1, 'aromatic': True}),],
-        [(0, 1, {'order': 1.5}),
-         (1, 2, {'order': 1.5}),
-         (2, 3, {'order': 1.5}),
-         (3, 4, {'order': 1.5}),
-         (4, 0, {'order': 1.5}),],
+        [(0, {'element': 'C', 'hcount': 1, 'aromatic': False}),
+         (1, {'element': 'C', 'hcount': 1, 'aromatic': False}),
+         (2, {'element': 'C', 'hcount': 1, 'aromatic': False}),
+         (3, {'element': 'C', 'hcount': 1, 'aromatic': False}),
+         (4, {'element': 'N', 'hcount': 1, 'aromatic': False}),],
+        [(0, 1, {'order': 2}),
+         (1, 2, {'order': 1}),
+         (2, 3, {'order': 2}),
+         (3, 4, {'order': 1}),
+         (4, 0, {'order': 1}),],
     ),
     (
         correct_aromatic_rings, {},
@@ -417,21 +441,22 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
          (3, 4, {}),
          (4, 0, {}),
          (4, 5, {})],
-        [(0, {'element': 'C', 'hcount': 1, 'aromatic': True}),
-         (1, {'element': 'C', 'hcount': 1, 'aromatic': True}),
-         (2, {'element': 'C', 'hcount': 1, 'aromatic': True}),
-         (3, {'element': 'C', 'hcount': 1, 'aromatic': True}),
-         (4, {'element': 'N', 'hcount': 0, 'aromatic': True}),
+        [(0, {'element': 'C', 'hcount': 1, 'aromatic': False}),
+         (1, {'element': 'C', 'hcount': 1, 'aromatic': False}),
+         (2, {'element': 'C', 'hcount': 1, 'aromatic': False}),
+         (3, {'element': 'C', 'hcount': 1, 'aromatic': False}),
+         (4, {'element': 'N', 'hcount': 0, 'aromatic': False}),
          (5, {'element': 'H', 'hcount': 0, 'aromatic': False})],
-        [(0, 1, {'order': 1.5}),
-         (1, 2, {'order': 1.5}),
-         (2, 3, {'order': 1.5}),
-         (3, 4, {'order': 1.5}),
-         (4, 0, {'order': 1.5}),
+        [(0, 1, {'order': 2}),
+         (1, 2, {'order': 1}),
+         (2, 3, {'order': 2}),
+         (3, 4, {'order': 1}),
+         (4, 0, {'order': 1}),
          (4, 5, {'order': 1})],
     ),
 ))
 def test_helper(helper, kwargs, n_data_in, e_data_in, n_data_out, e_data_out):
     mol = make_mol(n_data_in, e_data_in)
     helper(mol, **kwargs)
+    ref_mol = make_mol(n_data_out, e_data_out)
     assertEqualGraphs(mol, make_mol(n_data_out, e_data_out))


### PR DESCRIPTION
This is the initial draft of the new aromaticity algorithm following the ideas outlined [here](https://depth-first.com/articles/2021/06/30/writing-aromatic-smiles/) and [here](https://depth-first.com/articles/2020/02/10/a-comprehensive-treatment-of-aromaticity-in-the-smiles-language/).

The key difference is that we are not trying to assign chemical aromaticity but rather kekulize the molecule (i.e. fixing hcount). In a nutshell, the algorithm proceeds as follows:

1. Assign a preliminary hcount to all non-hydrogen atoms. This is a bit awkward but needed for the next step, because we want to be able to deal with cases where implicit hydrogen are part of the non-aromatic atoms. 
2. Remove all nodes that have a full valance, which we can only assess after implicit hydrogens have been added to non-aromatic residues. 
3. Get the connected components of the resulting fragmented graph. Each component has to be a delocalized system and is potentially aromatic. 
4. For each component we check if there exists a maximum matching and if that matching is perfect. If it is not perfect the delocalized system is written incorrectly and a syntax error is raised. It's like checking if we have perfect alternating single and double bonds. 
5a. If the system is cyclic we assume it to be (anti-)aromatic and give it a bond order of 1.5.  
5b. If it is not cyclic then we simply assign a bond order of 2 to the edges that constitute the perfect matching. 

Some differences in behaviour to the previous version:

| SMILES           | VALID | AROMATIC           | old                     | new   |
|------------------|-------|--------------------|-------------------------|-------|
| c1c[nH]cc1       | yes   | no                 | pass                    | pass  |
| c1cNcc1          | yes   | no                 | pass                    | pass  |
| c1cncc1          | no    | raises Error       | fail (no hydrogen on N) | pass  |
| c1cscc1          | yes   | no                 | fail                    | pass  |
| c1cScc1          | yes   | no                 | pass                    | pass  |
| c1cnc[nH]1       | yes   | no                 | pass                    | pass  |
| c1cncN1          | yes   | no                 | pass                    | pass  |
| N12ccccc1ccc2    | yes   | no                 | pass                    | pass  |
| n12ccccc1ccc2    | yes   | no                 | pass                    | pass  |
| c12ccccc1Ncc2    | yes   | only benz fragment | pass                    | pass  |
| c12ccccc1[nH]cc2 | yes   | only benz fragment | pass                    | pass  |
| c12ccccc1ncc2    | no    | raises Error       | fail (no hyrdogen on N) | error |
| c1cscn1          | yes   | no                 | fail                    | pass  |
| cccc             | yes   | no                 | fail (raises Error)     | pass  |

Overall I'd say this algorithm is more robust as it raises an Error for hard fails like `c1cncc1` but is also linenet towards chemically intuative smiles like `cccc`. 

The major problems are:

- how to deal with wildcards ?
- how to deal with charges in the intial valance assignment ? I think it should be `missing = valance - bonds + charges`