### PR TITLE
Redo the aromaticity algorithm (again) and simplify API by removing mark_aromatic_nodes/edges

### DIFF
--- a/pysmiles/read_smiles.py
+++ b/pysmiles/read_smiles.py
@@ -237,15 +237,22 @@ def read_smiles(smiles, explicit_hydrogen=False, zero_order_bonds=True,
     # a hcount, so all is well.
     fill_valence(mol)
 
-    if strict:
-        for node in mol:
-            element = mol.nodes[node].get('element', '*')
-            if element != '*' and element not in PTE:
-                raise KeyError(f'Unknown element {element}')
-            elif element != '*' and bonds_missing(mol, node):
-                debug_smiles = write_smiles_component(nx.ego_graph(mol, node))
-                raise KeyError(f'Node {node} ({format_atom(mol, node)}) has'
-                               f' non-standard valence: ...{debug_smiles}...')
+    for node in mol:
+        element = mol.nodes[node].get('element', '*')
+        if element != '*' and element not in PTE:
+            msg = f'Unknown element {element}'
+            if strict:
+                raise KeyError(msg)
+            else:
+                LOGGER.warning(msg)
+        elif element != '*' and bonds_missing(mol, node):
+            debug_smiles = write_smiles_component(nx.ego_graph(mol, node))
+            msg = (f'Node {node} ({format_atom(mol, node)}) has non-standard'
+                   f' valence: ...{debug_smiles}...')
+            if strict:
+                raise KeyError(msg)
+            else:
+                LOGGER.warning(msg)
 
     # post-processing of E/Z isomerism
     _annotate_ez_isomers(mol, ez_isomer_pairs)

--- a/pysmiles/read_smiles.py
+++ b/pysmiles/read_smiles.py
@@ -24,8 +24,8 @@ import networkx as nx
 
 from . import PTE
 from .smiles_helper import (add_explicit_hydrogens, remove_explicit_hydrogens,
-                            parse_atom, fill_valence, mark_aromatic_edges,
-                            mark_aromatic_atoms,  bonds_missing, format_atom,
+                            parse_atom, fill_valence, bonds_missing, format_atom,
+                            correct_aromatic_rings,
                             _mark_chiral_atoms, _annotate_ez_isomers)
 from .write_smiles import write_smiles_component
 
@@ -134,6 +134,7 @@ def read_smiles(smiles, explicit_hydrogen=False, zero_order_bonds=True,
     anchor = None
     idx = 0
     default_bond = 1
+    default_aromatic_bond = 1.5
     next_bond = None
     branches = []
     ring_nums = {}
@@ -146,7 +147,10 @@ def read_smiles(smiles, explicit_hydrogen=False, zero_order_bonds=True,
             mol.add_node(idx, **parse_atom(token))
             if anchor is not None:
                 if next_bond is None:
-                    next_bond = default_bond
+                    if mol.nodes[anchor].get('aromatic') and mol.nodes[idx].get('aromatic'):
+                        next_bond = default_aromatic_bond
+                    else:
+                        next_bond = default_bond
                 if next_bond or zero_order_bonds:
                     mol.add_edge(anchor, idx, order=next_bond)
                 next_bond = None
@@ -165,7 +169,10 @@ def read_smiles(smiles, explicit_hydrogen=False, zero_order_bonds=True,
             if token in ring_nums:
                 jdx, order = ring_nums[token]
                 if next_bond is None and order is None:
-                    next_bond = default_bond
+                    if mol.nodes[idx-1].get('aromatic') and mol.nodes[jdx].get('aromatic'):
+                        next_bond = default_aromatic_bond
+                    else:
+                        next_bond = default_bond
                 elif order is None:  # Note that the check is needed,
                     next_bond = next_bond  # But this could be pass.
                 elif next_bond is None:
@@ -223,10 +230,7 @@ def read_smiles(smiles, explicit_hydrogen=False, zero_order_bonds=True,
         raise ValueError('There is an unmatched stereochemical token.')
 
     if reinterpret_aromatic:
-        mark_aromatic_atoms(mol, strict=strict)
-        mark_aromatic_edges(mol)
-    else:
-        mark_aromatic_edges(mol)
+        correct_aromatic_rings(mol, strict=strict)
 
     # This is a bit of an overreach, we should only add implicit hydrogens to
     # atoms in the organic subset. However, all non-organic atoms already have

--- a/pysmiles/smiles_helper.py
+++ b/pysmiles/smiles_helper.py
@@ -632,11 +632,17 @@ def dekekulize(mol):
     # The idea is the following:
     # 1) only nodes in cycles can be aromatic (in the sense that they show DIME)
     # 2) only nodes that have a double bond can be aromatic
+    # 3) only nodes that have at least 1 single bond can be aromatic
     # Given those two requirements, the aromatic system is spanned by the
     # maximal matching
     cycles = nx.cycle_basis(mol)
     cycles_nodes = {n for cycle in cycles for n in cycle}
-    double_bond_atoms = {n for edge in mol.edges for n in edge if mol.edges[edge].get('order', 1) == 2}
+    bond_orders = {}
+    for node in mol:
+        # We'll make a set because we don't care how often each order is present,
+        # and this way we can do an easy subset comparison
+        bond_orders[node] = {mol[node][n].get('order', 1) for n in mol[node]}
+    double_bond_atoms = {n for n in bond_orders if {1, 2}  <= bond_orders[n]}
     maybe_aromatic = double_bond_atoms & cycles_nodes
     matching = nx.max_weight_matching(mol.subgraph(maybe_aromatic))
     aromatic_nodes = {n for e in matching for n in e}

--- a/tests/test_hypothesis.py
+++ b/tests/test_hypothesis.py
@@ -21,8 +21,8 @@ from hypothesis_networkx import graph_builder
 from pysmiles import read_smiles
 from pysmiles import write_smiles
 from pysmiles.smiles_helper import (
-    add_explicit_hydrogens, remove_explicit_hydrogens, mark_aromatic_atoms,
-    mark_aromatic_edges, fill_valence, correct_aromatic_rings,
+    add_explicit_hydrogens, remove_explicit_hydrogens, correct_aromatic_rings,
+    fill_valence,
     increment_bond_orders, kekulize, dekekulize)
 from pysmiles.testhelper import assertEqualGraphs
 

--- a/tests/test_read_smiles.py
+++ b/tests/test_read_smiles.py
@@ -840,3 +840,17 @@ def test_skip_kekulize(smiles):
     for node in g.nodes:
         assert g.nodes[node]['aromatic']
     assert g.edges[(0, 1)]['order'] == 1.5
+
+
+@pytest.mark.parametrize('smiles', (
+    'c1cc2ccc3c2c1cc3',
+    'c12cccc1c1cccc1cc2',
+    'c12c3c4c5c2c2c6c7c1c1c8c3c3c9c4c4c%10c5c5c2c2c6c6c%11c7c1c1c7c8c3c3c8c9c4c4c9c%10c5c5c2c2c6c6c%11c1c1c7c3c3c8c4c4c9c5c2c2c6c1c3c42',
+    'C1=CC2=CC=C3C2=C1C=C3',
+    'C1=C2C(=C3C=CC=C3C=C2)C=C1',
+    'C12=C3C4=C5C1=C1C6=C7C2=C2C8=C3C3=C9C4=C4C%10=C5C5=C1C1=C6C6=C%11C7=C2C2=C7C8=C3C3=C8C9=C4C4=C9C%10=C5C5=C1C1=C6C6=C%11C2=C2C7=C3C3=C8C4=C4C9=C5C1=C1C6=C2C3=C14',
+))
+def test_aromatic_molecules(smiles):
+    """These molecules are totally aromatic"""
+    mol = read_smiles(smiles, reinterpret_aromatic=True)
+    assert all(nx.get_node_attributes(mol, 'aromatic').values())

--- a/tests/test_read_smiles.py
+++ b/tests/test_read_smiles.py
@@ -615,6 +615,22 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
          (8, 9, {'order': 1.5})],
         False
     ),
+    (
+        'C1=CC=C=C=C1',
+        [(0, {'element': 'C', 'charge': 0, 'aromatic': False, 'hcount': 1}),
+         (1, {'element': 'C', 'charge': 0, 'aromatic': False, 'hcount': 1}),
+         (2, {'element': 'C', 'charge': 0, 'aromatic': False, 'hcount': 1}),
+         (3, {'element': 'C', 'charge': 0, 'aromatic': False, 'hcount': 0}),
+         (4, {'element': 'C', 'charge': 0, 'aromatic': False, 'hcount': 0}),
+         (5, {'element': 'C', 'charge': 0, 'aromatic': False, 'hcount': 1}),],
+        [(0, 1, {'order': 2}),
+         (1, 2, {'order': 1}),
+         (2, 3, {'order': 2}),
+         (3, 4, {'order': 2}),
+         (4, 5, {'order': 2}),
+         (0, 5, {'order': 1})],
+        False
+    ),
     # chiral center S/L alanine
     (
         'C[C@@H](C(=O)O)N',

--- a/tests/test_read_smiles.py
+++ b/tests/test_read_smiles.py
@@ -766,6 +766,22 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
          (2, 3, {'order': 1}),],
         False,
     ),
+    (
+        'C1=CC=C[SiH]=C1',
+        [(0, {'element': 'C', 'charge': 0, 'aromatic': False, 'hcount': 1}),
+         (1, {'element': 'C', 'charge': 0, 'aromatic': False, 'hcount': 1}),
+         (2, {'element': 'C', 'charge': 0, 'aromatic': False, 'hcount': 1}),
+         (3, {'element': 'C', 'charge': 0, 'aromatic': False, 'hcount': 1}),
+         (4, {'element': 'Si', 'charge': 0, 'aromatic': False, 'hcount': 1}),
+         (5, {'element': 'C', 'charge': 0, 'aromatic': False, 'hcount': 1}),],
+        [(0, 1, {'order': 2}),
+         (1, 2, {'order': 1}),
+         (2, 3, {'order': 2}),
+         (3, 4, {'order': 1}),
+         (4, 5, {'order': 2}),
+         (5, 0, {'order': 1}),],
+        False
+    )
 ))
 def test_read_smiles(smiles, node_data, edge_data, explicit_h):
     found = read_smiles(smiles, explicit_hydrogen=explicit_h)
@@ -785,6 +801,10 @@ def test_read_smiles(smiles, node_data, edge_data, explicit_h):
     ('1CCC1', ValueError),
     ('ccc', SyntaxError),
     ('C=1CC-1', ValueError),
+    ('[Uoo]', KeyError),
+    ('F/C=CF', ValueError),
+    ('C=.C', ValueError),
+    ('C[O@]C', ValueError),
 ))
 def test_invalid_smiles(smiles, error_type):
     with pytest.raises(error_type):

--- a/tests/test_smiles_helpers.py
+++ b/tests/test_smiles_helpers.py
@@ -16,8 +16,8 @@
 import pytest
 
 from pysmiles.smiles_helper import (
-    correct_aromatic_rings, fill_valence, remove_explicit_hydrogens,
-    add_explicit_hydrogens, mark_aromatic_atoms, mark_aromatic_edges,
+    fill_valence, remove_explicit_hydrogens,
+    add_explicit_hydrogens, correct_aromatic_rings,
     valence, kekulize, dekekulize,
 )
 from pysmiles.testhelper import assertEqualGraphs, make_mol
@@ -230,7 +230,7 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
     ),
     # 11
     (
-        mark_aromatic_atoms, {},
+        correct_aromatic_rings, {},
         [(0, {'element': 'C', 'hcount': 1, 'charge': 0}),
          (1, {'element': 'C', 'hcount': 1, 'charge': 0}),
          (2, {'element': 'C', 'hcount': 1, 'charge': 0}),
@@ -246,15 +246,15 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
          (2, {'element': 'C', 'hcount': 1, 'charge': 0, 'aromatic': True}),
          (3, {'element': 'C', 'hcount': 0, 'charge': 0, 'aromatic': True}),
          (4, {'element': 'C', 'hcount': 3, 'charge': 0, 'aromatic': False})],
-        [(0, 1, {'order': 2}),
-         (1, 2, {'order': 1}),
-         (2, 3, {'order': 2}),
-         (3, 0, {'order': 1}),
+        [(0, 1, {'order': 1.5}),
+         (1, 2, {'order': 1.5}),
+         (2, 3, {'order': 1.5}),
+         (3, 0, {'order': 1.5}),
          (3, 4, {'order': 1})],
     ),
     # 12
     (
-        mark_aromatic_atoms, {},
+        correct_aromatic_rings, {},
         [(0, {'element': 'C', 'hcount': 2, 'charge': 0}),
          (1, {'element': 'C', 'hcount': 2, 'charge': 0}),
          (2, {'element': 'C', 'hcount': 2, 'charge': 0}),
@@ -278,7 +278,7 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
     ),
     # 13
     (
-        mark_aromatic_atoms, {},
+        correct_aromatic_rings, {},
         [(0, {'element': 'C', 'hcount': 1, 'charge': 0}),
          (1, {'element': 'C', 'hcount': 1, 'charge': 0}),
          (2, {'element': 'C', 'hcount': 1, 'charge': 0}),
@@ -291,46 +291,14 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
          (1, {'element': 'C', 'hcount': 1, 'charge': 0, 'aromatic': True}),
          (2, {'element': 'C', 'hcount': 1, 'charge': 0, 'aromatic': True}),
          (3, {'hcount': 1, 'charge': 0, 'aromatic': True}),],
-        [(0, 1, {'order': 2}),
-         (1, 2, {'order': 1}),
-         (2, 3, {'order': 2}),
-         (3, 0, {'order': 1}),],
-    ),
-    # 14
-    (
-        mark_aromatic_edges, {},
-        [(0, {'charge': 1, 'aromatic': True}),
-         (1, {'charge': 0, 'aromatic': True}),
-         (2, {'charge': 0, 'aromatic': True}),],
-        [(0, 1, {'order': 1}),
-         (1, 2, {'order': 1}),
-         (2, 0, {'order': 1}),],
-        [(0, {'charge': 1, 'aromatic': True}),
-         (1, {'charge': 0, 'aromatic': True}),
-         (2, {'charge': 0, 'aromatic': True}),],
         [(0, 1, {'order': 1.5}),
          (1, 2, {'order': 1.5}),
-         (2, 0, {'order': 1.5}),],
-    ),
-    # 15
-    (
-        mark_aromatic_edges, {},
-        [(0, {'charge': 1, 'aromatic': True}),
-         (1, {'charge': 0, 'aromatic': True}),
-         (2, {'charge': 0, 'aromatic': True}),],
-        [(0, 1, {'order': 1}),
-         (1, 2, {'order': 1}),],
-        [(0, {'charge': 1, 'aromatic': True}),
-         (1, {'charge': 0, 'aromatic': True}),
-         (2, {'charge': 0, 'aromatic': True}),],
-        [(0, 1, {'order': 1.5}),
-         (1, 2, {'order': 1.5}),],
+         (2, 3, {'order': 1.5}),
+         (3, 0, {'order': 1.5}),],
     ),
     # 16
     (
-        # This case smells a bit. Not all atoms in a cycle are aromatic, so only
-        # some of the bonds become aromatic.
-        mark_aromatic_edges, {},
+        correct_aromatic_rings, {},
         [(0, {'charge': 1, 'aromatic': False}),
          (1, {'charge': 0, 'aromatic': True}),
          (2, {'charge': 0, 'aromatic': True}),],
@@ -338,31 +306,11 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
          (1, 2, {'order': 1}),
          (2, 0, {'order': 1}),],
         [(0, {'charge': 1, 'aromatic': False}),
-         (1, {'charge': 0, 'aromatic': True}),
-         (2, {'charge': 0, 'aromatic': True}),],
+         (1, {'charge': 0, 'aromatic': False}),
+         (2, {'charge': 0, 'aromatic': False}),],
         [(0, 1, {'order': 1}),
-         (1, 2, {'order': 1.5}),
+         (1, 2, {'order': 2}),
          (2, 0, {'order': 1}),],
-    ),
-    # 17
-    (
-        mark_aromatic_edges, {},
-        [(0, {'charge': 1, 'aromatic': True}),
-         (1, {'charge': 0, 'aromatic': True}),
-         (2, {'charge': 0, 'aromatic': True}),
-         (3, {'aromatic': False})],
-        [(0, 1, {'order': 1}),
-         (1, 2, {'order': 1}),
-         (2, 0, {'order': 1}),
-         (2, 3, {'order': 1})],
-        [(0, {'charge': 1, 'aromatic': True}),
-         (1, {'charge': 0, 'aromatic': True}),
-         (2, {'charge': 0, 'aromatic': True}),
-         (3, {'aromatic': False})],
-        [(0, 1, {'order': 1.5}),
-         (1, 2, {'order': 1.5}),
-         (2, 0, {'order': 1.5}),
-         (2, 3, {'order': 1})],
     ),
     # 18
     (
@@ -375,14 +323,14 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
          (1, 2, {}),
          (2, 3, {}),
          (3, 0, {})],
-        [(0, {'element': 'C', 'hcount': 2, 'aromatic': False}),
-         (1, {'element': 'C', 'hcount': 2, 'aromatic': False}),
-         (2, {'element': 'C', 'hcount': 2, 'aromatic': False}),
-         (3, {'element': 'C', 'hcount': 2, 'aromatic': False}),],
-        [(0, 1, {'order': 1}),
-         (1, 2, {'order': 1}),
-         (2, 3, {'order': 1}),
-         (3, 0, {'order': 1})],
+        [(0, {'element': 'C', 'aromatic': False}),
+         (1, {'element': 'C', 'aromatic': False}),
+         (2, {'element': 'C', 'aromatic': False}),
+         (3, {'element': 'C', 'aromatic': False}),],
+        [(0, 1, {}),
+         (1, 2, {}),
+         (2, 3, {}),
+         (3, 0, {})],
     ),
     # 19
     (
@@ -392,9 +340,28 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
          (2, {'element': 'C', 'hcount': 1}),
          (3, {'element': 'C', 'hcount': 1}),],
         [(0, 1, {}),
+         (1, 2, {'order': 2}),
+         (2, 3, {}),
+         (3, 0, {'order': 2}),],
+        [(0, {'element': 'C', 'hcount': 1, 'aromatic': True}),
+         (1, {'element': 'C', 'hcount': 1, 'aromatic': True}),
+         (2, {'element': 'C', 'hcount': 1, 'aromatic': True}),
+         (3, {'element': 'C', 'hcount': 1, 'aromatic': True}),],
+        [(0, 1, {'order': 1.5}),
+         (1, 2, {'order': 1.5}),
+         (2, 3, {'order': 1.5}),
+         (3, 0, {'order': 1.5})],
+    ),
+(
+        correct_aromatic_rings, {},
+        [(0, {'element': 'C', 'hcount': 1, 'aromatic': True}),
+         (1, {'element': 'C', 'hcount': 1, 'aromatic': True}),
+         (2, {'element': 'C', 'hcount': 1, 'aromatic': True}),
+         (3, {'element': 'C', 'hcount': 1, 'aromatic': True}),],
+        [(0, 1, {}),
          (1, 2, {}),
          (2, 3, {}),
-         (3, 0, {})],
+         (3, 0, {}),],
         [(0, {'element': 'C', 'hcount': 1, 'aromatic': True}),
          (1, {'element': 'C', 'hcount': 1, 'aromatic': True}),
          (2, {'element': 'C', 'hcount': 1, 'aromatic': True}),
@@ -418,9 +385,9 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
          (1, {'element': 'C', 'hcount': 1, 'aromatic': False}),
          (2, {'element': 'C', 'hcount': 1, 'aromatic': False}),
          (3, {'element': 'C', 'hcount': 1, 'aromatic': False}),],
-        [(0, 1, {'order': 2}),
-         (1, 2, {'order': 1}),
-         (2, 3, {'order': 2}),],
+        [(0, 1, {}),
+         (1, 2, {}),
+         (2, 3, {}),],
     ),
     # 21
     (
@@ -440,11 +407,11 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
          (2, {'element': 'C', 'hcount': 1, 'aromatic': False}),
          (3, {'element': 'C', 'hcount': 1, 'aromatic': False}),
          (4, {'element': 'O', 'hcount': 0, 'aromatic': False}),],
-        [(0, 1, {'order': 2}),
-         (1, 2, {'order': 1}),
-         (2, 3, {'order': 2}),
-         (3, 4, {'order': 1}),
-         (4, 0, {'order': 1})],
+        [(0, 1, {}),
+         (1, 2, {}),
+         (2, 3, {}),
+         (3, 4, {}),
+         (4, 0, {})],
     ),
     (
         correct_aromatic_rings, {},
@@ -463,11 +430,11 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
          (2, {'element': 'C', 'hcount': 1, 'aromatic': False}),
          (3, {'element': 'C', 'hcount': 1, 'aromatic': False}),
          (4, {'element': 'N', 'hcount': 1, 'aromatic': False}),],
-        [(0, 1, {'order': 2}),
-         (1, 2, {'order': 1}),
-         (2, 3, {'order': 2}),
-         (3, 4, {'order': 1}),
-         (4, 0, {'order': 1}),],
+        [(0, 1, {}),
+         (1, 2, {}),
+         (2, 3, {}),
+         (3, 4, {}),
+         (4, 0, {}),],
     ),
     (
         correct_aromatic_rings, {},
@@ -487,17 +454,17 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
          (1, {'element': 'C', 'hcount': 1, 'aromatic': False}),
          (2, {'element': 'C', 'hcount': 1, 'aromatic': False}),
          (3, {'element': 'C', 'hcount': 1, 'aromatic': False}),
-         (4, {'element': 'N', 'hcount': 0, 'aromatic': False}),
+         (4, {'element': 'N', 'aromatic': False}),
          (5, {'element': 'H', 'aromatic': False})],
-        [(0, 1, {'order': 2}),
-         (1, 2, {'order': 1}),
-         (2, 3, {'order': 2}),
-         (3, 4, {'order': 1}),
-         (4, 0, {'order': 1}),
-         (4, 5, {'order': 1})],
+        [(0, 1, {}),
+         (1, 2, {}),
+         (2, 3, {}),
+         (3, 4, {}),
+         (4, 0, {}),
+         (4, 5, {})],
     ),
     (
-        mark_aromatic_atoms, {},
+        correct_aromatic_rings, {},
         [(0, {'element': 'C', 'hcount': 1, 'aromatic': True}),
          (1, {'element': 'C', 'hcount': 1, 'aromatic': True}),
          (2, {'element': 'C', 'hcount': 1, 'aromatic': True}),
@@ -510,10 +477,10 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
          (1, {'element': 'C', 'hcount': 1, 'aromatic': True}),
          (2, {'element': 'C', 'hcount': 1, 'aromatic': True}),
          (3, {'element': '*', 'hcount': 1, 'aromatic': True}),],
-        [(0, 1, {'order': 1}),
-         (1, 2, {'order': 1}),
-         (2, 3, {'order': 1}),
-         (0, 3, {'order': 1}),],
+        [(0, 1, {'order': 1.5}),
+         (1, 2, {'order': 1.5}),
+         (2, 3, {'order': 1.5}),
+         (0, 3, {'order': 1.5}),],
     ),
     (
         kekulize, {},
@@ -555,9 +522,14 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
     ),
 ))
 def test_helper(helper, kwargs, n_data_in, e_data_in, n_data_out, e_data_out):
+    print(f'{helper=} {kwargs=}')
+    print(f'{n_data_in=} {e_data_in=}')
+    print(f'{n_data_out=} {e_data_out=}')
     mol = make_mol(n_data_in, e_data_in)
     helper(mol, **kwargs)
     ref_mol = make_mol(n_data_out, e_data_out)
+    print(mol.nodes(data=True))
+    print(mol.edges(data=True))
     assertEqualGraphs(mol, ref_mol)
 
 


### PR DESCRIPTION
The redesign of the algorithm was required, because although the old algorithm produced correct results, it was prohibitively slow for molecules such as buckyballs. The new algorithm hinges on the following:
- all aromatic atoms (=atoms part of a molecular fragment that shows DIME) are in at least one ring
- all aromatic atoms have a double bond
- The maximum matching of the induced subgraph spanned by those nodes is the aromatic system

I'm still running the smilesreading test battery (github.com/nextmovesoftware/smilesreading), so WIP.