### PR TITLE
Ez multi

### DIFF
--- a/pysmiles/read_smiles.py
+++ b/pysmiles/read_smiles.py
@@ -26,7 +26,7 @@ from . import PTE
 from .smiles_helper import (add_explicit_hydrogens, remove_explicit_hydrogens,
                             parse_atom, fill_valence, bonds_missing, format_atom,
                             correct_aromatic_rings,
-                            _mark_chiral_atoms, annotate_ez_isomers)
+                            _mark_chiral_atoms, _annotate_ez_isomers)
 from .write_smiles import write_smiles_component
 
 LOGGER = logging.getLogger(__name__)
@@ -245,7 +245,7 @@ def read_smiles(smiles, explicit_hydrogen=False, zero_order_bonds=True,
                 LOGGER.warning(msg)
 
     # post-processing of E/Z isomerism
-    annotate_ez_isomers(mol, ez_isomer_atoms)
+    _annotate_ez_isomers(mol, ez_isomer_atoms)
     # post-processing of chiral atoms
     _mark_chiral_atoms(mol)
 

--- a/pysmiles/smiles_helper.py
+++ b/pysmiles/smiles_helper.py
@@ -911,14 +911,20 @@ def _annotate_ez_isomers(molecule, ez_pairs):
             elif ez_first == '\\' and ez_second == '\\':  # pragma: no branch
                 ez_isomer = 'cis'
         assert ez_isomer is not None
+
+        if molecule.nodes[ligand_first].get('ez_isomer', False):
+            molecule.nodes[ligand_first]['ez_isomer'] = []
+
+        if molecule.nodes[ligand_second].get('ez_isomer', False):
+            molecule.nodes[ligand_second]['ez_isomer'] = []
         # annotate ligands
-        molecule.nodes[ligand_first]['ez_isomer'] = (ligand_first,
-                                                     anchor_first,
-                                                     anchor_second,
-                                                     ligand_second,
-                                                     ez_isomer)
-        molecule.nodes[ligand_second]['ez_isomer'] = (ligand_second,
-                                                      anchor_second,
-                                                      anchor_first,
-                                                      ligand_first,
-                                                      ez_isomer)
+        molecule.nodes[ligand_first]['ez_isomer'].append((ligand_first,
+                                                          anchor_first,
+                                                          anchor_second,
+                                                          ligand_second,
+                                                          ez_isomer))
+        molecule.nodes[ligand_second]['ez_isomer'].append((ligand_second,
+                                                           anchor_second,
+                                                           anchor_first,
+                                                           ligand_first,
+                                                           ez_isomer))

--- a/pysmiles/smiles_helper.py
+++ b/pysmiles/smiles_helper.py
@@ -894,7 +894,7 @@ def annotate_ez_isomers(molecule, ez_atoms):
             continue
         if anchor1 not in ez_atoms or anchor2 not in ez_atoms:
             if anchor1 in ez_atoms or anchor2 in ez_atoms:
-                msg = ("Dangling E/Z isomer token for double bond between {anchor1} {anchor2}.")
+                msg = (f"Dangling E/Z isomer token for double bond between {anchor1} {anchor2}.")
                 raise ValueError(msg)
             continue
         anchors = [anchor1, anchor2]

--- a/tests/test_hypothesis.py
+++ b/tests/test_hypothesis.py
@@ -35,7 +35,7 @@ NODE_DATA = st.fixed_dictionaries({
 }).map(lambda d: {k: v for k, v in d.items() if v is not None})
 FRAGMENTS = st.sampled_from('C O N P S c1ccccc1 C(=O)[O-] C(=O)O *'.split())
 
-@settings(max_examples=500, stateful_step_count=100, deadline=None)
+@settings(max_examples=500, stateful_step_count=50, deadline=None)
 class SMILESTest(RuleBasedStateMachine):
     @initialize(fragment=FRAGMENTS)
     def setup(self, fragment):

--- a/tests/test_read_smiles.py
+++ b/tests/test_read_smiles.py
@@ -768,10 +768,10 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
         False,
     ),
     (r'F\C=C\F',
-        [(0, {'element': 'F', 'charge': 0, 'aromatic': False, 'hcount': 0, 'ez_isomer': (0, 1, 2, 3, 'trans')}),
+        [(0, {'element': 'F', 'charge': 0, 'aromatic': False, 'hcount': 0, 'ez_isomer': [(0, 1, 2, 3, 'trans')]}),
          (1, {'element': 'C', 'charge': 0, 'aromatic': False, 'hcount': 1}),
          (2, {'element': 'C', 'charge': 0, 'aromatic': False, 'hcount': 1}),
-         (3, {'element': 'F', 'charge': 0, 'aromatic': False, 'hcount': 0, 'ez_isomer': (3, 2, 1, 0, 'trans')}),],
+         (3, {'element': 'F', 'charge': 0, 'aromatic': False, 'hcount': 0, 'ez_isomer': [(3, 2, 1, 0, 'trans')]}),],
         [(0, 1, {'order': 1}),
          (1, 2, {'order': 2}),
          (2, 3, {'order': 1}),],
@@ -779,9 +779,9 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
     ),
     (r'C(/F)=C\F',
         [(0, {'element': 'C', 'charge': 0, 'aromatic': False, 'hcount': 1}),
-         (1, {'element': 'F', 'charge': 0, 'aromatic': False, 'hcount': 0, 'ez_isomer': (1, 0, 2, 3, 'trans')}),
+         (1, {'element': 'F', 'charge': 0, 'aromatic': False, 'hcount': 0, 'ez_isomer': [(1, 0, 2, 3, 'trans')]}),
          (2, {'element': 'C', 'charge': 0, 'aromatic': False, 'hcount': 1}),
-         (3, {'element': 'F', 'charge': 0, 'aromatic': False, 'hcount': 0, 'ez_isomer': (3, 2, 0, 1, 'trans')}),],
+         (3, {'element': 'F', 'charge': 0, 'aromatic': False, 'hcount': 0, 'ez_isomer': [(3, 2, 0, 1, 'trans')]}),],
         [(0, 1, {'order': 1}),
          (0, 2, {'order': 2}),
          (2, 3, {'order': 1}),],
@@ -789,9 +789,9 @@ from pysmiles.testhelper import assertEqualGraphs, make_mol
     ),
     (r'C(\F)=C\F',
         [(0, {'element': 'C', 'charge': 0, 'aromatic': False, 'hcount': 1}),
-         (1, {'element': 'F', 'charge': 0, 'aromatic': False, 'hcount': 0, 'ez_isomer': (1, 0, 2, 3, 'cis')}),
+         (1, {'element': 'F', 'charge': 0, 'aromatic': False, 'hcount': 0, 'ez_isomer': [(1, 0, 2, 3, 'cis')]}),
          (2, {'element': 'C', 'charge': 0, 'aromatic': False, 'hcount': 1}),
-         (3, {'element': 'F', 'charge': 0, 'aromatic': False, 'hcount': 0, 'ez_isomer': (3, 2, 0, 1, 'cis')}),],
+         (3, {'element': 'F', 'charge': 0, 'aromatic': False, 'hcount': 0, 'ez_isomer': [(3, 2, 0, 1, 'cis')]}),],
         [(0, 1, {'order': 1}),
          (0, 2, {'order': 2}),
          (2, 3, {'order': 1}),],
@@ -959,20 +959,25 @@ def test_chiral(smiles, expected):
 
 
 @pytest.mark.parametrize('smiles, records',[
-    (r'F/C=C/F', [(0, 1, 2, 3, 'trans'), (3, 2, 1, 0, 'trans')]),
-    (r'C(\F)=C/F', [(1, 0, 2, 3, 'trans'), (3, 2, 0, 1, 'trans')]),
-    (r'F\C=C/F', [(0, 1, 2, 3, 'cis'), (3, 2, 1, 0, 'cis')]),
-    (r'C(/F)=C/F', [(1, 0, 2, 3, 'cis'), (3, 2, 0, 1, 'cis')]),
-    (r'F/C(CC)=C/F', [(0, 1, 4, 5, 'trans'), (5, 4, 1, 0, 'trans')]),
-    (r'F/C=C=C=C/F', [(0, 1, 4, 5, 'trans'), (5, 4, 1, 0, 'trans')]),
-    (r'F/C=C=C=C\F', [(0, 1, 4, 5, 'cis'), (5, 4, 1, 0, 'cis')]),
+    (r'F/C=C/F', [[(0, 1, 2, 3, 'trans')], [(3, 2, 1, 0, 'trans')]]),
+    (r'C(\F)=C/F', [[(1, 0, 2, 3, 'trans')], [(3, 2, 0, 1, 'trans')]]),
+    (r'F\C=C/F', [[(0, 1, 2, 3, 'cis')], [(3, 2, 1, 0, 'cis')]]),
+    (r'C(/F)=C/F', [[(1, 0, 2, 3, 'cis')], [(3, 2, 0, 1, 'cis')]]),
+    (r'F/C(CC)=C/F', [[(0, 1, 4, 5, 'trans')], [(5, 4, 1, 0, 'trans')]]),
+    (r'F/C(/F)=C(/F)', [[(0, 1, 3, 4, 'trans')],
+                        [(2, 1, 3, 4, 'cis')],
+                        [(4, 3, 1, 0, 'trans'),
+                         (4, 3, 1, 2, 'cis')]]),
+   # (r'F/C=C=C=C/F', [(0, 1, 4, 5, 'trans'), (5, 4, 1, 0, 'trans')]),
+   # (r'F/C=C=C=C\F', [(0, 1, 4, 5, 'cis'), (5, 4, 1, 0, 'cis')]),
     ('c1ccccc1', None)
 ])
 def test_cis_trans_reading(smiles, records):
     mol = read_smiles(smiles, explicit_hydrogen=False)
     if records:
         for record in records:
-            assert mol.nodes[record[0]]['ez_isomer'] == record
+            for ez_item in record:
+                assert mol.nodes[ez_item[0]]['ez_isomer'] == record
     else:
         assert len(nx.get_node_attributes(mol, 'ez_isomer')) == 0
 


### PR DESCRIPTION
This PR fixes E/Z assignment for some edge cases (e.g. `F\C=C\C=C\F`). In addition, it raises an error for invalid SMILES like `(F\)C=C`. In doing so it unfixes extended CIS/TRANS (e.g. `F\C=C=C=C\F`). I think it is worth not including these at the moment. It does throw an error for the extended CIS/TRANS. It also handles multiple CIS/TRANS per double bond (e.g. `C(\F)(/F)=C(/Cl)(\Br)` and checks if they are compatible. 