### PR TITLE
Update networkx version specification in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ setup-requires =
     pbr
 install-requires =  # ?? requires-dist?
     pbr
-    networkx
+    networkx ~= 3.0
 zip-safe = False
 
 [pbr]


### PR DESCRIPTION
Update NX requirements to 3.x, which is needed because of the length_bound argument in simple_cycles.