### PR TITLE
ENH: broaden SMILES handling to match RDKit

### DIFF
--- a/pysmiles/read_smiles.py
+++ b/pysmiles/read_smiles.py
@@ -18,7 +18,6 @@ Exposes functionality needed for parsing SMILES strings.
 """
 
 import enum
-import re
 import logging
 
 import networkx as nx
@@ -186,7 +185,7 @@ def base_smiles_parser(smiles, strict=True, node_attr='desc', edge_attr='desc'):
                 if idx - 1 == jdx:
                     raise ValueError('Marker {} specifies a bond between an '
                                      'atom and itself'.format(token))
-                mol.add_edge(idx - 1, jdx, **{edge_attr: next_bond, '_pos': token_idx})
+                mol.add_edge(anchor, jdx, **{edge_attr: next_bond, '_pos': token_idx})
                 next_bond = None
                 del ring_nums[token]
                 # we need to keep track of ring bonds here for the
@@ -245,14 +244,10 @@ def read_smiles(smiles, explicit_hydrogen=False, zero_order_bonds=True,
         information.
         Edges will have an 'order'.
     """
-    # sanitize invalid SMILES input that is accepted by RDKit
-    # see: https://github.com/gruenewald-lab/CGsmiles/issues/70#issuecomment-4750353505
-    pattern = r'(\(=[A-Z]\))(\d)'
-    mod_smiles = re.sub(pattern, r'\2\1', smiles)
     bond_to_order = {'-': 1, '=': 2, '#': 3, '$': 4, ':': 1.5, '.': 0}
     default_bond = 1
     default_aromatic_bond = 1.5
-    mol, ez_isomer_atoms, ring_bonds = base_smiles_parser(mod_smiles, strict=strict,
+    mol, ez_isomer_atoms, ring_bonds = base_smiles_parser(smiles, strict=strict,
                                                           node_attr='_atom_str', edge_attr='_bond_str')
     for node in mol:
         mol.nodes[node].update(parse_atom(mol.nodes[node]['_atom_str']))

--- a/pysmiles/read_smiles.py
+++ b/pysmiles/read_smiles.py
@@ -18,6 +18,7 @@ Exposes functionality needed for parsing SMILES strings.
 """
 
 import enum
+import re
 import logging
 
 import networkx as nx
@@ -244,10 +245,14 @@ def read_smiles(smiles, explicit_hydrogen=False, zero_order_bonds=True,
         information.
         Edges will have an 'order'.
     """
+    # sanitize invalid SMILES input that is accepted by RDKit
+    # see: https://github.com/gruenewald-lab/CGsmiles/issues/70#issuecomment-4750353505
+    pattern = r'(\(=[A-Z]\))(\d)'
+    mod_smiles = re.sub(pattern, r'\2\1', smiles)
     bond_to_order = {'-': 1, '=': 2, '#': 3, '$': 4, ':': 1.5, '.': 0}
     default_bond = 1
     default_aromatic_bond = 1.5
-    mol, ez_isomer_atoms, ring_bonds = base_smiles_parser(smiles, strict=strict,
+    mol, ez_isomer_atoms, ring_bonds = base_smiles_parser(mod_smiles, strict=strict,
                                                           node_attr='_atom_str', edge_attr='_bond_str')
     for node in mol:
         mol.nodes[node].update(parse_atom(mol.nodes[node]['_atom_str']))

--- a/pysmiles/read_smiles.py
+++ b/pysmiles/read_smiles.py
@@ -179,10 +179,10 @@ def base_smiles_parser(smiles, strict=True, node_attr='desc', edge_attr='desc'):
                     raise ValueError('Conflicting bond orders for ring '
                                      'between indices {}'.format(token))
                 # idx is the index of the *next* atom we're adding. So: -1.
-                if mol.has_edge(idx - 1, jdx):
+                if mol.has_edge(anchor, jdx):
                     raise ValueError('Edge specified by marker {} already '
                                      'exists'.format(token))
-                if idx - 1 == jdx:
+                if anchor == jdx:
                     raise ValueError('Marker {} specifies a bond between an '
                                      'atom and itself'.format(token))
                 mol.add_edge(anchor, jdx, **{edge_attr: next_bond, '_pos': token_idx})
@@ -190,7 +190,7 @@ def base_smiles_parser(smiles, strict=True, node_attr='desc', edge_attr='desc'):
                 del ring_nums[token]
                 # we need to keep track of ring bonds here for the
                 # chirality assignment
-                created_ring_bonds.append((idx-1, jdx, {edge_attr: next_bond, '_pos': token_idx}))
+                created_ring_bonds.append((anchor, jdx, {edge_attr: next_bond, '_pos': token_idx}))
             else:
                 if idx == 0:
                     raise ValueError("Can't have a marker ({}) before an atom"

--- a/tests/test_read_smiles.py
+++ b/tests/test_read_smiles.py
@@ -1022,3 +1022,25 @@ def test_aromatic_molecules(smiles):
     """These molecules are totally aromatic"""
     mol = read_smiles(smiles, reinterpret_aromatic=True)
     assert all(nx.get_node_attributes(mol, 'aromatic').values())
+
+
+@pytest.mark.parametrize("smiles", [
+    # these are both interpreted as the same
+    # molecule in RDKit
+    "C(c1c2cccc3c2c(cc1)C(=C)C(=C)C(=C)3)",
+    "C(c1c2cccc3c2c(cc1)C(=C)C(=C)C3(=C))"
+])
+def test_non_canonical_smiles_handling(smiles):
+    # harmonizing SMILES input handling to better match RDKit
+    # can help accommodate SMILES strings provided by chemists
+    # per:
+    # https://github.com/gruenewald-lab/CGsmiles/issues/70
+    mol = read_smiles(smiles)
+    # expected values are from the "good" string at:
+    # https://github.com/gruenewald-lab/CGsmiles/issues/70#issuecomment-4750353505
+    expected_nodes = list(range(17))
+    expected_edges = [(0, 1), (1, 2), (1, 10), (2, 3), (2, 7), (3, 4), (4, 5),
+                      (5, 6), (6, 7), (6, 15), (7, 8), (8, 9), (8, 11), (9, 10),
+                      (11, 12), (11, 13), (13, 14), (13, 15), (15, 16)]
+    assert list(mol.nodes) == expected_nodes
+    assert list(mol.edges) == expected_edges


### PR DESCRIPTION
* Related to a small part of https://github.com/gruenewald-lab/CGsmiles/issues/70.

* One of the problematic SMILES permutations that RDKit considers isomorphic with a more canonical SMILES was not handled properly by `pysmiles`. This is a small shim (via regex) and regression test to start enforcing equivalence for at least this one extra permutation.

* It is possible to generate many more scrambled/randomized SMILES permutations in RDKit, but for now this one extra permutation is the closest to what the chemists provided me, so is of most interest to me at least.

* In local testing I don't see any problems, altough `tests/test_hypothesis.py::Tester::runTest` seems to fail for me even on `master` (decent chance it could be my recent version of `hypothesis`, which can change case generation by version).

------------------

AI usage disclaimer: I did ask an LLM to help me draft the regex for moving the ring termination number relative to the parenthetical double bond. The regression test I wrote myself based on in house needs.