### PR TITLE
Make ring bond markers more lenient towards branching

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,9 @@ element attribute.
     information in the SMILES string.
 - `strict` determines whether the function be a bit more critical about what 
     constitutes a valid SMILES string. In particular, checks whether the 
-    specified aromatic fragments can be kekulized, and whether atom valency 
-    is sensible. 
+    specified aromatic fragments can be kekulized, whether atom valency 
+    is sensible, and (within limitations) whether the string follows the 
+    OpenSMILES specification. 
 
 ### Stereochemical information
 Tetrahedral chirality is stored on nodes in the 'rs_isomer' attribute. It 

--- a/pysmiles/read_smiles.py
+++ b/pysmiles/read_smiles.py
@@ -76,6 +76,8 @@ def _tokenize(smiles):
                 token += char
                 if char == ']':
                     break
+            else: # nobreak
+                raise SyntaxError('Invalid SMILES: unmatched atom bracket')
             yield TokenType.ATOM, idx, token
         elif char in organic_subset:
             peek = next(smiles, '')
@@ -96,7 +98,7 @@ def _tokenize(smiles):
             yield TokenType.RING_NUM, idx, int(next(smiles, '') + next(smiles, ''))
         elif char in '/\\':
             yield TokenType.EZSTEREO, idx, char
-        elif char.isdigit():
+        elif char.isdigit():  # pragma: no branch
             yield TokenType.RING_NUM, idx, int(char)
 
 
@@ -166,6 +168,9 @@ def base_smiles_parser(smiles, strict=True, node_attr='desc', edge_attr='desc'):
                                  'Overwritten by "{}"'.format(next_bond, token))
             next_bond = token
         elif tokentype == TokenType.RING_NUM:
+            if anchor is None:
+                raise ValueError("Can't have a marker ({}) before an atom"
+                                 "".format(token))
             if anchor != idx - 1:
                 msg = ('Marker %i appears after a branch closing, which is'
                        ' invalid SMILES according to the OpenSMILES specification.'
@@ -201,13 +206,10 @@ def base_smiles_parser(smiles, strict=True, node_attr='desc', edge_attr='desc'):
                 # chirality assignment
                 created_ring_bonds.append((anchor, jdx, {edge_attr: next_bond, '_pos': token_idx}))
             else:
-                if anchor is None:
-                    raise ValueError("Can't have a marker ({}) before an atom"
-                                     "".format(token))
                 # idx is the index of the *next* atom we're adding. So: -1.
                 ring_nums[token] = (anchor, next_bond)
                 next_bond = None
-        elif tokentype == TokenType.EZSTEREO:
+        elif tokentype == TokenType.EZSTEREO:  # pragma: no branch
             ez_isomer_atoms[anchor] = token
             ez_isomer_atoms[idx] = token
         prev_token = token

--- a/pysmiles/read_smiles.py
+++ b/pysmiles/read_smiles.py
@@ -188,7 +188,7 @@ def base_smiles_parser(smiles, strict=True, node_attr='desc', edge_attr='desc'):
 
                 if anchor != idx-1:
                     msg = ('Marker %i appears after a branch closing, which is'
-                           ' invalid smiles according to the OpenSMILES specification.'
+                           ' invalid SMILES according to the OpenSMILES specification.'
                            ' Rather than specifying the marker after the branch'
                            ' (`C(O)1`), it should appear before (`C1(O)`).')
                     if strict:

--- a/pysmiles/read_smiles.py
+++ b/pysmiles/read_smiles.py
@@ -96,7 +96,7 @@ def _tokenize(smiles):
             yield TokenType.RING_NUM, idx, int(next(smiles, '') + next(smiles, ''))
         elif char in '/\\':
             yield TokenType.EZSTEREO, idx, char
-        elif char.isdigit():  # pragma: no branch
+        elif char.isdigit():
             yield TokenType.RING_NUM, idx, int(char)
 
 
@@ -140,7 +140,6 @@ def base_smiles_parser(smiles, strict=True, node_attr='desc', edge_attr='desc'):
     next_bond = None
     branches = []
     ring_nums = {}
-    current_ez = None
     ez_isomer_atoms = {}
     created_ring_bonds = []
     prev_token = None
@@ -216,9 +215,6 @@ def base_smiles_parser(smiles, strict=True, node_attr='desc', edge_attr='desc'):
 
     if ring_nums and strict:
         raise KeyError('Unmatched ring indices {}'.format(list(ring_nums.keys())))
-
-    if current_ez and strict:
-        raise ValueError('There is an unmatched stereochemical token.')
 
     return mol, ez_isomer_atoms, created_ring_bonds
 

--- a/pysmiles/read_smiles.py
+++ b/pysmiles/read_smiles.py
@@ -128,7 +128,7 @@ def base_smiles_parser(smiles, strict=True, node_attr='desc', edge_attr='desc'):
         ``_pos``.
     List[Tuple[Tuple[int, int, str], Tuple[int, int, str]]]
         A list of E/Z isomer pairs, where the integers are node indices and last
-        element is the directional token from the smiles string (*i.e.* / or \).
+        element is the directional token from the smiles string (*i.e.* / or \\).
     List[Tuple[int, int, {edge_attr: str, '_pos': int}]
         A list of created ring bonds, to be used for R/S isomer annotation. It
         contains tuples consisting of 2 node indices, and a dictionary
@@ -192,11 +192,11 @@ def base_smiles_parser(smiles, strict=True, node_attr='desc', edge_attr='desc'):
                 # chirality assignment
                 created_ring_bonds.append((anchor, jdx, {edge_attr: next_bond, '_pos': token_idx}))
             else:
-                if idx == 0:
+                if anchor is None:
                     raise ValueError("Can't have a marker ({}) before an atom"
                                      "".format(token))
                 # idx is the index of the *next* atom we're adding. So: -1.
-                ring_nums[token] = (idx - 1, next_bond)
+                ring_nums[token] = (anchor, next_bond)
                 next_bond = None
         elif tokentype == TokenType.EZSTEREO:  # pragma: no branch
             ez_isomer_atoms[anchor] = token

--- a/pysmiles/read_smiles.py
+++ b/pysmiles/read_smiles.py
@@ -72,7 +72,7 @@ def _tokenize(smiles):
             break
         if char == '[':
             token = char
-            for char in smiles:  # pragma: no branch
+            for char in smiles:
                 token += char
                 if char == ']':
                     break
@@ -208,7 +208,7 @@ def base_smiles_parser(smiles, strict=True, node_attr='desc', edge_attr='desc'):
                 # idx is the index of the *next* atom we're adding. So: -1.
                 ring_nums[token] = (anchor, next_bond)
                 next_bond = None
-        elif tokentype == TokenType.EZSTEREO:  # pragma: no branch
+        elif tokentype == TokenType.EZSTEREO:
             ez_isomer_atoms[anchor] = token
             ez_isomer_atoms[idx] = token
         prev_token = token

--- a/pysmiles/read_smiles.py
+++ b/pysmiles/read_smiles.py
@@ -167,6 +167,15 @@ def base_smiles_parser(smiles, strict=True, node_attr='desc', edge_attr='desc'):
                                  'Overwritten by "{}"'.format(next_bond, token))
             next_bond = token
         elif tokentype == TokenType.RING_NUM:
+            if anchor != idx - 1:
+                msg = ('Marker %i appears after a branch closing, which is'
+                       ' invalid SMILES according to the OpenSMILES specification.'
+                       ' Rather than specifying the marker after the branch'
+                       ' (`C(O)1`), it should appear before (`C1(O)`).')
+                if strict:
+                    raise ValueError(msg % token)
+                else:
+                    LOGGER.warning(msg, token)
             if token in ring_nums:
                 jdx, order = ring_nums[token]
                 if next_bond is None and order is None:
@@ -186,15 +195,6 @@ def base_smiles_parser(smiles, strict=True, node_attr='desc', edge_attr='desc'):
                     raise ValueError('Marker {} specifies a bond between an '
                                      'atom and itself'.format(token))
 
-                if anchor != idx-1:
-                    msg = ('Marker %i appears after a branch closing, which is'
-                           ' invalid SMILES according to the OpenSMILES specification.'
-                           ' Rather than specifying the marker after the branch'
-                           ' (`C(O)1`), it should appear before (`C1(O)`).')
-                    if strict:
-                        raise ValueError(msg % token)
-                    else:
-                        LOGGER.warning(msg, token)
                 mol.add_edge(anchor, jdx, **{edge_attr: next_bond, '_pos': token_idx})
                 next_bond = None
                 del ring_nums[token]

--- a/pysmiles/read_smiles.py
+++ b/pysmiles/read_smiles.py
@@ -185,6 +185,16 @@ def base_smiles_parser(smiles, strict=True, node_attr='desc', edge_attr='desc'):
                 if anchor == jdx:
                     raise ValueError('Marker {} specifies a bond between an '
                                      'atom and itself'.format(token))
+
+                if anchor != idx-1:
+                    msg = ('Marker %i appears after a branch closing, which is'
+                           ' invalid smiles according to the OpenSMILES specification.'
+                           ' Rather than specifying the marker after the branch'
+                           ' (`C(O)1`), it should appear before (`C1(O)`).')
+                    if strict:
+                        raise ValueError(msg % token)
+                    else:
+                        LOGGER.warning(msg, token)
                 mol.add_edge(anchor, jdx, **{edge_attr: next_bond, '_pos': token_idx})
                 next_bond = None
                 del ring_nums[token]

--- a/pysmiles/smiles_helper.py
+++ b/pysmiles/smiles_helper.py
@@ -144,7 +144,7 @@ def format_atom(molecule, node_key, default_element='*'):
     aromatic = node.get('aromatic', False)
     default_h = has_default_h_count(molecule, node_key)
 
-    if stereo is not None or node.get('ez_isomer'):  # pragma: nocover
+    if stereo is not None or node.get('ez_isomer'):
         LOGGER.warning("The SMILES writer does not write stereochemical information")
 
     if aromatic and name in AROMATIC_ATOMS:
@@ -242,8 +242,7 @@ def add_explicit_hydrogens(mol):
         `mol` is modified in-place.
     """
     h_atom = parse_atom('[H]')
-    if 'hcount' in h_atom:  # pragma: nocover; defensive
-        del h_atom['hcount']
+    del h_atom['hcount']
     for n_idx in list(mol.nodes):
         hcount = mol.nodes[n_idx].get('hcount', 0)
         idxs = range(max(mol) + 1, max(mol) + hcount + 1)
@@ -965,10 +964,10 @@ def _interpret_cis_trans_tokens(molecule, ez_pairs):
             elif ez_first == '/' and ez_second == '\\':
                 ez_isomer = 'cis'
             # case 4 F\C=C\F
-            elif ez_first == '\\' and ez_second == '\\':  # pragma: no branch
+            elif ez_first == '\\' and ez_second == '\\':
                 ez_isomer = 'trans'
         # as in C(/F)=C
-        elif ligand_first > anchor_first:  # pragma: no branch
+        elif ligand_first > anchor_first:
             # case 5 C(\F)=C/F is trans
             if ez_first == '\\' and ez_second == '/':
                 ez_isomer = 'trans'
@@ -979,7 +978,7 @@ def _interpret_cis_trans_tokens(molecule, ez_pairs):
             elif ez_first == '/' and ez_second == '\\':
                 ez_isomer = 'trans'
             # case 8 C(\F)=C\F
-            elif ez_first == '\\' and ez_second == '\\':  # pragma: no branch
+            elif ez_first == '\\' and ez_second == '\\':
                 ez_isomer = 'cis'
         assert ez_isomer is not None
 

--- a/pysmiles/smiles_helper.py
+++ b/pysmiles/smiles_helper.py
@@ -964,10 +964,10 @@ def _interpret_cis_trans_tokens(molecule, ez_pairs):
             elif ez_first == '/' and ez_second == '\\':
                 ez_isomer = 'cis'
             # case 4 F\C=C\F
-            elif ez_first == '\\' and ez_second == '\\':
+            elif ez_first == '\\' and ez_second == '\\':  # pragma: no branch
                 ez_isomer = 'trans'
         # as in C(/F)=C
-        elif ligand_first > anchor_first:
+        elif ligand_first > anchor_first:  # pragma: no branch
             # case 5 C(\F)=C/F is trans
             if ez_first == '\\' and ez_second == '/':
                 ez_isomer = 'trans'
@@ -978,7 +978,7 @@ def _interpret_cis_trans_tokens(molecule, ez_pairs):
             elif ez_first == '/' and ez_second == '\\':
                 ez_isomer = 'trans'
             # case 8 C(\F)=C\F
-            elif ez_first == '\\' and ez_second == '\\':
+            elif ez_first == '\\' and ez_second == '\\':  # pragma: no branch
                 ez_isomer = 'cis'
         assert ez_isomer is not None
 

--- a/tests/test_read_smiles.py
+++ b/tests/test_read_smiles.py
@@ -1035,7 +1035,7 @@ def test_non_canonical_smiles_handling(smiles):
     # can help accommodate SMILES strings provided by chemists
     # per:
     # https://github.com/gruenewald-lab/CGsmiles/issues/70
-    mol = read_smiles(smiles)
+    mol = read_smiles(smiles, strict=False)
     # expected values are from the "good" string at:
     # https://github.com/gruenewald-lab/CGsmiles/issues/70#issuecomment-4750353505
     expected_nodes = list(range(17))

--- a/tests/test_read_smiles.py
+++ b/tests/test_read_smiles.py
@@ -17,6 +17,7 @@ import pytest
 import networkx as nx
 from pysmiles import read_smiles
 from pysmiles.testhelper import assertEqualGraphs, make_mol
+import logging
 
 
 @pytest.mark.parametrize('smiles, node_data, edge_data, explicit_h', (
@@ -929,6 +930,8 @@ def test_read_smiles(smiles, node_data, edge_data, explicit_h):
     ('C[O@]C', ValueError),
     ('CC(C)(=C)C', KeyError),
     ('CCCCCCCC$C', KeyError),
+    ('C.C(O)1C.C1', ValueError),
+    ('C1.C(O)1C.C', ValueError),
 ))
 def test_invalid_smiles(smiles, error_type):
     with pytest.raises(error_type):
@@ -1044,3 +1047,16 @@ def test_non_canonical_smiles_handling(smiles):
                       (11, 12), (11, 13), (13, 14), (13, 15), (15, 16)]
     assert list(mol.nodes) == expected_nodes
     assert list(mol.edges) == expected_edges
+
+
+@pytest.mark.parametrize("smiles, loglevel, kwargs", [
+    ('CC.C(O)1C.CC1', logging.WARNING, dict(strict=False)),
+    ('C1C.C(O)1C.CC', logging.WARNING, dict(strict=False)),
+
+
+])
+def test_logging(caplog, smiles, loglevel, kwargs):
+    with caplog.at_level(loglevel):
+        read_smiles(smiles, **kwargs)
+    relevant_records = [record for record in caplog.records if record.levelno == loglevel]
+    assert len(relevant_records) == 1

--- a/tests/test_read_smiles.py
+++ b/tests/test_read_smiles.py
@@ -934,7 +934,6 @@ def test_read_smiles(smiles, node_data, edge_data, explicit_h):
     ('C1.C(O)1C.C', ValueError),
     ('(C)', SyntaxError),
     ('1CC1', ValueError),
-    # ('BrC/=CF', ValueError),
 ))
 def test_invalid_smiles(smiles, error_type):
     with pytest.raises(error_type):

--- a/tests/test_read_smiles.py
+++ b/tests/test_read_smiles.py
@@ -932,6 +932,9 @@ def test_read_smiles(smiles, node_data, edge_data, explicit_h):
     ('CCCCCCCC$C', KeyError),
     ('C.C(O)1C.C1', ValueError),
     ('C1.C(O)1C.C', ValueError),
+    ('(C)', SyntaxError),
+    ('1CC1', ValueError),
+    # ('BrC/=CF', ValueError),
 ))
 def test_invalid_smiles(smiles, error_type):
     with pytest.raises(error_type):
@@ -1052,7 +1055,8 @@ def test_non_canonical_smiles_handling(smiles):
 @pytest.mark.parametrize("smiles, loglevel, kwargs", [
     ('CC.C(O)1C.CC1', logging.WARNING, dict(strict=False)),
     ('C1C.C(O)1C.CC', logging.WARNING, dict(strict=False)),
-
+    ('[X]', logging.WARNING, dict(strict=False)),
+    ('[CH5]', logging.WARNING, dict(strict=False)),
 
 ])
 def test_logging(caplog, smiles, loglevel, kwargs):

--- a/tests/test_read_smiles.py
+++ b/tests/test_read_smiles.py
@@ -934,6 +934,7 @@ def test_read_smiles(smiles, node_data, edge_data, explicit_h):
     ('C1.C(O)1C.C', ValueError),
     ('(C)', SyntaxError),
     ('1CC1', ValueError),
+    ('[CH4', SyntaxError),
 ))
 def test_invalid_smiles(smiles, error_type):
     with pytest.raises(error_type):
@@ -1056,10 +1057,11 @@ def test_non_canonical_smiles_handling(smiles):
     ('C1C.C(O)1C.CC', logging.WARNING, dict(strict=False)),
     ('[X]', logging.WARNING, dict(strict=False)),
     ('[CH5]', logging.WARNING, dict(strict=False)),
-
+    ('c1cc1', logging.WARNING, dict(strict=False)),
 ])
-def test_logging(caplog, smiles, loglevel, kwargs):
+def test_readsmiles_logging(caplog, smiles, loglevel, kwargs):
     with caplog.at_level(loglevel):
         read_smiles(smiles, **kwargs)
     relevant_records = [record for record in caplog.records if record.levelno == loglevel]
     assert len(relevant_records) == 1
+

--- a/tests/test_smiles_helpers.py
+++ b/tests/test_smiles_helpers.py
@@ -20,7 +20,7 @@ from pysmiles.smiles_helper import (
     fill_valence, remove_explicit_hydrogens,
     add_explicit_hydrogens, correct_aromatic_rings,
     valence, kekulize, dekekulize, increment_bond_orders,
-    _bonds, _reorder_cycle, _check_for_ez_conflicts,
+    format_atom, _bonds, _reorder_cycle, _check_for_ez_conflicts,
     _interpret_cis_trans_tokens,
 )
 from pysmiles.testhelper import assertEqualGraphs, make_mol
@@ -624,6 +624,15 @@ def test_increment_bond_orders_skips_edges_once_a_node_is_satisfied(caplog):
 
     assert sorted(edge['order'] for *_, edge in mol.edges(data=True)) == [1, 3]
     assert 'Unable to completely assign bond orders from valence.' in caplog.text
+
+
+def test_format_atom_warns_for_stereochemistry(caplog):
+    mol = make_mol([(0, {'element': 'C', 'rs_isomer': ('clockwise', ())})], [])
+
+    with caplog.at_level('WARNING'):
+        assert format_atom(mol, 0) == '[C]'
+
+    assert 'does not write stereochemical information' in caplog.text
 
 
 @pytest.mark.parametrize('anchor, tagged_nodes, ez_isomer_class', [

--- a/tests/test_smiles_helpers.py
+++ b/tests/test_smiles_helpers.py
@@ -662,3 +662,16 @@ def test_interpret_cis_trans_tokens_marks_case_three_as_cis():
 
     assert mol.nodes[0]['ez_isomer'] == [(0, 1, 2, 3, 'cis')]
     assert mol.nodes[3]['ez_isomer'] == [(3, 2, 1, 0, 'cis')]
+
+
+def test_increment_bond_orders_no_warning_when_all_satisfied(caplog):
+    mol = make_mol(
+        [(0, {'element': 'N'}),
+         (1, {'element': 'N'})],
+        [(0, 1, {'order': 2})],
+    )
+    with caplog.at_level('WARNING'):
+        increment_bond_orders(mol, max_bond_order=3)
+
+    assert mol.edges[0, 1]['order'] == 3
+    assert not caplog.records

--- a/tests/test_smiles_helpers.py
+++ b/tests/test_smiles_helpers.py
@@ -543,6 +543,7 @@ def test_helper(helper, kwargs, n_data_in, e_data_in, n_data_out, e_data_out):
     ({'element': 'P'}, [3, 5]),
     ({'element': 'N', 'charge': 1}, [4]),
     ({'element': 'B', 'charge': 1}, [2]),
+    ({'element': '*'}, []),
 ])
 def test_valence(atom, expected):
     found = valence(atom)
@@ -633,6 +634,12 @@ def test_format_atom_warns_for_stereochemistry(caplog):
         assert format_atom(mol, 0) == '[C]'
 
     assert 'does not write stereochemical information' in caplog.text
+
+
+def test_format_atom_formats_single_hydrogen_and_multiplied_charge():
+    mol = make_mol([(0, {'element': 'N', 'hcount': 1, 'charge': 2})], [])
+
+    assert format_atom(mol, 0) == '[NH+2]'
 
 
 @pytest.mark.parametrize('anchor, tagged_nodes, ez_isomer_class', [

--- a/tests/test_smiles_helpers.py
+++ b/tests/test_smiles_helpers.py
@@ -14,11 +14,14 @@
 # limitations under the License.
 
 import pytest
+import networkx as nx
 
 from pysmiles.smiles_helper import (
     fill_valence, remove_explicit_hydrogens,
     add_explicit_hydrogens, correct_aromatic_rings,
-    valence, kekulize, dekekulize,
+    valence, kekulize, dekekulize, increment_bond_orders,
+    _bonds, _reorder_cycle, _check_for_ez_conflicts,
+    _interpret_cis_trans_tokens,
 )
 from pysmiles.testhelper import assertEqualGraphs, make_mol
 
@@ -553,3 +556,93 @@ def test_valence(atom, expected):
 def test_valence_error(atom):
     with pytest.raises(ValueError):
         valence(atom)
+
+
+def test_bonds_without_order_counts_neighbors():
+    mol = make_mol(
+        [(0, {'element': 'C'}), (1, {'element': 'N'})],
+        [(0, 1, {'order': 3})],
+    )
+
+    assert _bonds(mol, 0, use_order=False) == 1
+
+
+def test_correct_aromatic_rings_warns_for_unmatched_aromatic_region(caplog):
+    mol = make_mol(
+        [(0, {'element': 'C', 'hcount': 1, 'aromatic': True}),
+         (1, {'element': 'C', 'hcount': 1, 'aromatic': True}),
+         (2, {'element': 'C', 'hcount': 1, 'aromatic': True})],
+        [(0, 1, {'order': 1.5}),
+         (1, 2, {'order': 1.5}),
+         (2, 0, {'order': 1.5})],
+    )
+
+    with caplog.at_level('WARNING'):
+        correct_aromatic_rings(mol, strict=False)
+
+    assert 'Your molecule is invalid and cannot be kekulized.' in caplog.text
+    assert sorted(edge['order'] for *_, edge in mol.edges(data=True)) == [1, 1, 2]
+
+
+def test_kekulize_rejects_non_kekulizable_aromatic_region():
+    mol = make_mol(
+        [(0, {'element': 'C', 'hcount': 1, 'aromatic': True}),
+         (1, {'element': 'C', 'hcount': 1, 'aromatic': True}),
+         (2, {'element': 'C', 'hcount': 1, 'aromatic': True})],
+        [(0, 1, {'order': 1.5}),
+         (1, 2, {'order': 1.5}),
+         (2, 0, {'order': 1.5})],
+    )
+
+    with pytest.raises(ValueError, match='Aromatic region cannot be kekulized.'):
+        kekulize(mol)
+
+
+def test_reorder_cycle_returns_empty_for_no_nodes():
+    assert _reorder_cycle(nx.Graph(), []) == []
+
+
+def test_reorder_cycle_raises_for_non_cycle():
+    graph = nx.path_graph([0, 1, 2])
+    graph.add_node(3)
+
+    with pytest.raises(nx.NetworkXNoCycle, match='Not a cycle'):
+        _reorder_cycle(graph, [0, 1, 2, 3])
+
+
+def test_increment_bond_orders_skips_edges_once_a_node_is_satisfied(caplog):
+    mol = make_mol(
+        [(0, {'element': 'C'}),
+         (1, {'element': 'C'}),
+         (2, {'element': 'C'})],
+        [(0, 1, {'order': 1}),
+         (1, 2, {'order': 1})],
+    )
+
+    with caplog.at_level('WARNING'):
+        increment_bond_orders(mol)
+
+    assert sorted(edge['order'] for *_, edge in mol.edges(data=True)) == [1, 3]
+    assert 'Unable to completely assign bond orders from valence.' in caplog.text
+
+
+@pytest.mark.parametrize('anchor, tagged_nodes, ez_isomer_class', [
+    (5, (1, 2), {1: '/', 2: '/'}),
+    (2, (1, 3), {1: '/', 3: '\\'}),
+])
+def test_check_for_ez_conflicts_raises(anchor, tagged_nodes, ez_isomer_class):
+    with pytest.raises(ValueError, match='Conflicting cis/trans assignment'):
+        _check_for_ez_conflicts(anchor, tagged_nodes, ez_isomer_class)
+
+
+def test_check_for_ez_conflicts_allows_distinct_same_side_tokens():
+    _check_for_ez_conflicts(5, (1, 2), {1: '/', 2: '\\'})
+
+
+def test_interpret_cis_trans_tokens_marks_case_three_as_cis():
+    mol = make_mol([(0, {}), (1, {}), (2, {}), (3, {})], [])
+
+    _interpret_cis_trans_tokens(mol, [[[0, 1, '/'], [3, 2, '\\']]])
+
+    assert mol.nodes[0]['ez_isomer'] == [(0, 1, 2, 3, 'cis')]
+    assert mol.nodes[3]['ez_isomer'] == [(3, 2, 1, 0, 'cis')]

--- a/tests/test_write_smiles.py
+++ b/tests/test_write_smiles.py
@@ -158,3 +158,39 @@ def test_write_smiles(node_data, edge_data, kwargs):
     print(kwargs)
     found = read_smiles(smiles, **kwargs)
     assertEqualGraphs(mol, found, excluded_node_attrs=['_pos', '_atom_str'], excluded_edge_attrs=['_pos', '_bond_str'])
+
+
+def test_write_smiles_with_start_node():
+    mol = make_mol(
+        [(0, {'element': 'C', 'charge': 0, 'aromatic': False, 'hcount': 3}),
+         (1, {'element': 'C', 'charge': 0, 'aromatic': False, 'hcount': 3})],
+        [(0, 1, {'order': 1})]
+    )
+    smiles = write_smiles(mol, start=1)
+    found = read_smiles(smiles, zero_order_bonds=True, reinterpret_aromatic=True)
+    assertEqualGraphs(mol, found, excluded_node_attrs=['_pos', '_atom_str'], excluded_edge_attrs=['_pos', '_bond_str'])
+
+
+def test_write_smiles_ring_double_bond():
+    mol = make_mol(
+        [(0, {'element': 'C', 'charge': 0, 'aromatic': False, 'hcount': 1}),
+         (1, {'element': 'C', 'charge': 0, 'aromatic': False, 'hcount': 2}),
+         (2, {'element': 'C', 'charge': 0, 'aromatic': False, 'hcount': 1})],
+        [(0, 1, {'order': 1}),
+         (1, 2, {'order': 1}),
+         (0, 2, {'order': 2})]
+    )
+    smiles = write_smiles(mol)
+    found = read_smiles(smiles, zero_order_bonds=True, reinterpret_aromatic=True)
+    assertEqualGraphs(mol, found, excluded_node_attrs=['_pos', '_atom_str'], excluded_edge_attrs=['_pos', '_bond_str'])
+
+
+def test_write_smiles_disconnected_with_start():
+    mol = make_mol(
+        [(0, {'element': 'C', 'charge': 0, 'aromatic': False, 'hcount': 4}),
+         (1, {'element': 'C', 'charge': 0, 'aromatic': False, 'hcount': 4})],
+        []
+    )
+    smiles = write_smiles(mol, start=1)
+    found = read_smiles(smiles, zero_order_bonds=False, reinterpret_aromatic=True)
+    assertEqualGraphs(mol, found, excluded_node_attrs=['_pos', '_atom_str'], excluded_edge_attrs=['_pos', '_bond_str'])


### PR DESCRIPTION
@tylerjereddy I still missed one in #60.  
In all cases ring bonds should be made to anchors (`anchor`), rather than simply the previous atom (`idx-1`). If normal atoms are added, these automatically become the next anchor, which means that "normal" operations are not affected. The change is in everything branch related. This should fix all `...)1..1` and `..1..)1` flavoured ring markers.

I also added extra coverage tests in `tests/test_smiles_helpers.py` to exercise previously untested `smiles_helper.py` edge cases and bring that module's coverage to 100%.